### PR TITLE
Add override to remove bottom margin in breadcrumb

### DIFF
--- a/app/assets/sass/explore-govuk-overrides.scss
+++ b/app/assets/sass/explore-govuk-overrides.scss
@@ -22,6 +22,10 @@ $govuk-secondary-text-colour: #505a5f;
   &__link:link, &__link:visited, &__link:hover, &__link:active, &__link:focus {
     color: $govuk-secondary-text-colour;
   }
+
+  .govuk-breadcrumbs__list-item {
+    margin-bottom: 0;
+  }
 }
 
 


### PR DESCRIPTION
There's extraneous margin bottom in the breadcrumb and doesn't match the design.

Trello https://trello.com/c/tlBk0aFA/248-implement-new-breadcrumb-design

## Screenshots

### Before / After
<img width="428" alt="Screenshot 2021-04-22 at 17 56 18" src="https://user-images.githubusercontent.com/424772/115754429-15227880-a394-11eb-80fe-5a1a85525b9d.png">
