### PR TITLE
Fix Sass compilation errors

### DIFF
--- a/app/assets/sass/explore-header.scss
+++ b/app/assets/sass/explore-header.scss
@@ -10,7 +10,7 @@ $link-hover-colour: #003078;
 $menu-hover-colour: #005ff8;
 
 $govuk-link-underline-thickness: 0.0625rem !default;
-$govuk-heavy-link-underline-thickness: $govuk-link-underline-thickness * 3;
+$govuk-heavy-link-underline-thickness: 3px;
 $govuk-link-hover-underline-thickness: unquote("max(.1875rem, .12em)") !default;
 $govuk-link-underline-offset: 0.15em !default;
 $govuk-text-colour: govuk-colour("black") !default;
@@ -126,7 +126,7 @@ $font: "GDS Transport", nta, Arial, sans-serif;
       }
 
       a:hover {
-        margin-bottom: $govuk-link-underline-thickness * 3;
+        margin-bottom: 3px;
       }
     }
   }
@@ -348,7 +348,7 @@ $font: "GDS Transport", nta, Arial, sans-serif;
       text-decoration-thickness: $govuk-link-underline-thickness;
 
       &:hover {
-        text-decoration-thickness: $govuk-link-underline-thickness *3;
+        text-decoration-thickness: 3px;
       }
     }
   }
@@ -359,7 +359,7 @@ $font: "GDS Transport", nta, Arial, sans-serif;
       text-decoration-thickness: $govuk-link-underline-thickness;
 
       &:hover {
-        text-decoration-thickness: $govuk-link-underline-thickness *3;
+        text-decoration-thickness: 3px;
       }
     }
   }

--- a/app/assets/sass/explore.scss
+++ b/app/assets/sass/explore.scss
@@ -325,7 +325,7 @@ $wide-width: 1300px;
       border-bottom: $govuk-link-underline-thickness solid;
 
       &:hover {
-        margin-bottom: $govuk-link-underline-thickness * -1;
+        margin-bottom: -3px;
         border-bottom: $govuk-link-underline-thickness solid;
       }
     }
@@ -458,7 +458,7 @@ $wide-width: 1300px;
   // Override footer links
   #footer {
     a:hover {
-      text-decoration-thickness: $govuk-link-underline-thickness * 3;
+      text-decoration-thickness: 3px;
     }
   }
 

--- a/app/assets/sass/xpl-link-styles.scss
+++ b/app/assets/sass/xpl-link-styles.scss
@@ -31,6 +31,6 @@ $govuk-text-colour: govuk-colour("black") !default;
 }
 
 %xpl-link-hover {
-  margin-bottom: $govuk-link-underline-thickness * -1;
+  margin-bottom: 3px;
   border-bottom: $govuk-link-hover-underline-thickness solid;
 }


### PR DESCRIPTION
The Heroku deployment silently failed. Deleting locally cached files showed that the sass compilation was failing on `max() * x` errors.

The result was the site missing all styles.