### PR TITLE
Fix passing params to search

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -164,8 +164,8 @@ const augmentedBody = function (req, response, body) {
 // Constructs the URL to get the page body from on gov.uk
 const govUkUrl = function (req) {
   var urlParts = new URL(req.url, 'https://www.gov.uk')
-  var query = urlParts.query
-  return 'https://www.gov.uk' + req.path + (query? '?' + query : '')
+  var query = urlParts.search
+  return 'https://www.gov.uk' + req.path + (query? query : '')
 }
 
 router.get('/*', function (req,res) {


### PR DESCRIPTION
A change from a deprecated api call previously silently broke parsing of query parameters [1]

See [1](https://github.com/alphagov/explore-prototype-4/commit/72a0a28e955ab6a96c31087c26292ec1292a02f0#diff-7a376e91d12506280221660e967d4d20d351ec828c27687778dc8db99a1d3a9dR166)