### PR TITLE
Update prototype breadcrumbs

### DIFF
--- a/app/assets/sass/explore-govuk-overrides.scss
+++ b/app/assets/sass/explore-govuk-overrides.scss
@@ -27,24 +27,26 @@ $govuk-secondary-text-colour: #505a5f;
     list-style: none;
     display: flex;
     position: relative;
-    margin-right: 10px;
-    margin-left: 5px;
-    padding-left: 20px;
+    margin-right: 35px;
+    margin-bottom: 5px;
 
-    &:first-child {
-      margin-left: 0;
-      padding-left: 0;
+    &:last-child {
+      margin-right: 0;
     }
 
     &:before {
+      border: none;
+    }
+
+    &:after {
       content: "";
       position: absolute;
       top: 0;
       bottom: 0;
-      left: -3.3px;
+      right: -20px;
       width: 7px;
       height: 7px;
-      margin: auto 0;
+      margin: 4px 0 0;
       -webkit-transform: rotate(45deg);
       -ms-transform: rotate(45deg);
       transform: rotate(45deg);
@@ -53,15 +55,15 @@ $govuk-secondary-text-colour: #505a5f;
       border-color: $govuk-secondary-text-colour;
     }
 
-    &:first-child {
-      &:before {
+    &:last-child {
+      &:after {
         border: none;
       }
     }
+  }
 
-    &__link:link, &__link:visited, &__link:hover, &__link:active, &__link:focus {
-      color: $govuk-secondary-text-colour;
-    }
+  &__link:link, &__link:visited, &__link:hover, &__link:active, &__link:focus {
+    color: $govuk-secondary-text-colour;
   }
 }
 
@@ -88,7 +90,7 @@ $govuk-secondary-text-colour: #505a5f;
 @media (min-width: 40.0625em) {
   .govuk-breadcrumbs {
     width: calc(100vw - 60px);
-    padding: 30px;
+    padding: 30px 30px 25px;
     margin-left: calc(50% - 50vw);
     margin-right: calc(50% - 50vw);
 
@@ -96,6 +98,10 @@ $govuk-secondary-text-colour: #505a5f;
       max-width: 960px;
       margin-left: auto;
       margin-right: auto;
+    }
+
+    .govuk-breadcrumbs__list-item:after {
+      margin: auto 0;
     }
   }
 }

--- a/app/assets/sass/explore.scss
+++ b/app/assets/sass/explore.scss
@@ -351,7 +351,13 @@ $wide-width: 1300px;
       margin: 0;
       padding: 0;
       list-style-position: outside;
-      margin-bottom: govuk-em(30px, 16px);
+      margin-bottom: govuk-em(25px, 16px);
+      display: flex;
+      @include govuk-clearfix;
+
+      @include govuk-media-query($from: $desktop-width) {
+        display: block;
+      }
 
       li {
         margin:0;
@@ -359,24 +365,26 @@ $wide-width: 1300px;
         list-style: none;
         display: flex;
         position: relative;
-        margin-right: 10px;
-        margin-left: 5px;
-        padding-left: 20px;
+        margin-right: 35px;
+        margin-bottom: 5px;
 
-        &:first-child {
-          margin-left: 0;
-          padding-left: 0;
+        @include govuk-media-query($from: $desktop-width) {
+          float: left;
         }
 
-        &:before {
+        &:last-child {
+          margin-right: 0;
+        }
+
+        &:after {
            content:"";
            position:absolute;
            top: 0;
            bottom:0;
-           left: -3.3px;
+           right: -20px;
            width:7px;
            height:7px;
-           margin:auto 0;
+           margin: 7px 0 0;
            -webkit-transform:rotate(45deg);
            -ms-transform:rotate(45deg);
            transform:rotate(45deg);
@@ -385,9 +393,8 @@ $wide-width: 1300px;
            border-color:#f3f2f1;
         }
 
-        &:first-child {
-          display: inline-block;
-          &:before {
+        &:last-child {
+          &:after {
             border: none;
           }
         }


### PR DESCRIPTION
## What
Moves a few elements around on the breadcrumb style override.

## Why
To adhere to the latest prototype breadcrumb design and fix a minor visual issue (see visual changes).

## Visual changes
The only visual change applies to small screens when breadcrumb content is very long ([example page on live](https://www.gov.uk/oneoff-decision-personal-welfare)).

| Before | After |
| --- | --- |
| ![Screenshot 2021-08-24 at 16 57 16](https://user-images.githubusercontent.com/64783893/130651771-440ee756-41fc-4ca6-934d-0f9dff8b50e8.png) | ![Screenshot 2021-08-24 at 16 55 52](https://user-images.githubusercontent.com/64783893/130651802-ae5b941b-45a8-41f9-9bdb-ff8a13a38674.png) |