### PR TITLE
Update step nav header design

### DIFF
--- a/app/assets/sass/explore-govuk-overrides.scss
+++ b/app/assets/sass/explore-govuk-overrides.scss
@@ -172,3 +172,23 @@ $govuk-secondary-text-colour: #505a5f;
 margin-bottom: $govuk-heavy-link-underline-thickness * -1;
 border-bottom: $govuk-heavy-link-underline-thickness solid;
 */
+
+.gem-c-step-nav-header {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  margin-top: 30px;
+  font-size: 16px;
+
+  @media (min-width: 40.0625em) {
+    font-size: 19px;
+  }
+}
+
+.gem-c-step-nav-header__part-of {
+  font-weight: normal;
+}
+
+.gem-c-title.govuk-\!-margin-top-8 {
+  margin-top: 15px !important;
+}


### PR DESCRIPTION
## What
Updates the design for the step by step nav header, or **superbreadcrumb**, as used on collection and step-by-step content pages.

## Why
To adhere to the new "part of" design in preparation for updates to breadcrumb behaviour.

[Card](https://trello.com/c/3ocSECIr/249-implement-new-superbreadcrumb-design)

## Visual changes
| Path | Before | After |
| --- | --- | --- |
| /government/collections/moving-goods-into-out-of-or-through-northern-ireland | ![Screenshot 2021-08-25 at 16 13 57](https://user-images.githubusercontent.com/64783893/130817357-e039dcd3-b716-46ff-9843-d4883f743361.png) | ![Screenshot 2021-08-25 at 16 02 01](https://user-images.githubusercontent.com/64783893/130817047-819d0a4b-8fa0-4545-8958-71de15ca2cf1.png) |
| /guidance/foreign-travel-insurance | ![Screenshot 2021-08-25 at 16 14 22](https://user-images.githubusercontent.com/64783893/130817400-822c399f-8b6c-4e85-985a-2fce1d80f299.png) | ![Screenshot 2021-08-25 at 16 02 21](https://user-images.githubusercontent.com/64783893/130817084-0388e05a-cb88-4b97-a6a2-437578351237.png) |