### PR TITLE
Fix clearfix sass bug

### DIFF
--- a/app/assets/sass/explore.scss
+++ b/app/assets/sass/explore.scss
@@ -353,7 +353,12 @@ $wide-width: 1300px;
       list-style-position: outside;
       margin-bottom: govuk-em(25px, 16px);
       display: flex;
-      @include govuk-clearfix;
+
+      &:after {
+        content: "";
+        display: block;
+        clear: both;
+      }
 
       @include govuk-media-query($from: $desktop-width) {
         display: block;


### PR DESCRIPTION
## What and why
Removes a call to `govuk-clearix` and replaces it with the contents of said clearfix. This for some reason was causing an error to fire in the sass compiler. This ensures that actual sass bugs aren't obscured by this.