### PR TITLE
Get body content working on guides

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -38,8 +38,13 @@ module.exports = function (env) {
 
   ------------------------------------------------------------------ */
 
+  filters.isArray = function(a) {
+    return Array.isArray(a)
+  }
+
   /* ------------------------------------------------------------------
     keep the following line to return your filters to the app
   ------------------------------------------------------------------ */
+
   return filters
 }

--- a/app/views/generic_template.html
+++ b/app/views/generic_template.html
@@ -98,13 +98,24 @@
             <div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">
               {{ documents|safe }}
             </div>
-
-            <h2 class="gem-c-heading gem-c-heading--font-size-27 gem-c-heading--mobile-top-margin">Details</h2>
           {% endif %}
-          
-          <div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">
-            {{ details|safe }}
-          </div>
+
+          {% if (details|isArray) %}
+            {% for item in details %}
+              <h2 class="gem-c-heading gem-c-heading--font-size-27 gem-c-heading--mobile-top-margin" id="{{item.slug}}">{{item.title}}</h2>
+              <div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">
+                {{ item.body|safe }}
+              </div>
+            {% endfor %}
+          {% else %}
+            {% if documents %}
+              <h2 class="gem-c-heading gem-c-heading--font-size-27 gem-c-heading--mobile-top-margin">Details</h2>
+            {% endif %}
+            
+            <div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">
+              {{ details|safe }}
+            </div>
+          {% endif %}
 
           <div class="app-c-published-dates app-c-published-dates--history" id="history" data-module="gem-toggle" lang="en">
             Published {{ metadata.first_published }}


### PR DESCRIPTION
## What
Accounts for if the body copy of a page is organised in `parts` instead of the typical `details` attribute. [Example page](https://www.gov.uk/appeal-lawful-development-certificate-decision).

## Why
So that we can effectively test guides as part of our page level navigation prototype.

Relies on https://github.com/alphagov/govuk-explore-api-prototype/pull/14

The format of guides in this change are different from how they behave on live. It doesn't separate parts of the guide into different pages, instead rendering all the text as different headings. This has been deemed to not be a major issue as this is specific behaviour isn't part of our research needs.

## How it looks (based on example page)
![localhost_3000_appeal-lawful-development-certificate-decision](https://user-images.githubusercontent.com/64783893/134666073-b79e29fd-9fdb-439f-9b44-7c88b161ad4f.png)
