### PR TITLE
Allow for dynamic context phrases

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -182,7 +182,7 @@ router.get('/*', function (req,res) {
   const contentApiUrl = `https://www.gov.uk/api/content/${originalUrl}`
   request(contentApiUrl, { json: true }, (error, result, body) => {
     if (error) throw error
-    const contentType = body.document_type
+    const contentType = body.schema_name
     
     if (supportedDocumentTypes.includes(contentType)) {
       const protoApiUrl = `${API_URL}/generic?slug=${originalUrl}`

--- a/app/views/generic_template.html
+++ b/app/views/generic_template.html
@@ -49,7 +49,10 @@
 
           <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-8 govuk-!-padding-top-0">{{ title }}</h1>
           <p class="lede govuk-body-l">
-            <strong>Guidance</strong> &mdash; {{ description }}
+            {% if context %}
+            <strong>{{context}}</strong> &mdash;
+            {% endif %}
+            {{ description }}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## What
Allow for context phrases to be passed from the API.

## Why
So we can properly test this change to page level navigation.

[Test page](https://www.gov.uk/government/publications/local-council-tax-support-schemes-an-independent-review)

Relies on https://github.com/alphagov/govuk-explore-api-prototype/pull/15