### PR TITLE
Define content types for page level nav prototype

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -172,10 +172,11 @@ const govUkUrl = function (req) {
 router.get('/*', function (req,res) {
   const supportedDocumentTypes = [
     'detailed_guide',
-    'guidance',
+    'document_collection',
     'guide',
+    'html_publication',
+    'local_transaction',
     'publication',
-    'statutory_guidance',
   ]
   const originalUrl = req.originalUrl
 


### PR DESCRIPTION
## What/Why
Now that we know what topic we're using for the next round of research and which content types are in that topic, this change defines exactly what content types we'll be using and therefore what content types to hijack for the generic content template.