### PR TITLE
Amend styling and rules for related nav toggling

### DIFF
--- a/app/assets/sass/xpl-related-nav.scss
+++ b/app/assets/sass/xpl-related-nav.scss
@@ -41,6 +41,7 @@
   border: 0;
   background: transparent;
   padding: 0;
+  margin: govuk-spacing(2) 0;
   @include govuk-font(16);
   color: govuk-colour("blue");
   cursor: pointer;
@@ -67,6 +68,10 @@
   }
 
   &:focus:hover {
+    .xpl-related-nav__toggle-text {
+      text-decoration: none;
+    }
+
     .xpl-related-nav__toggle-chevron {
       color: govuk-colour("black");
       background: govuk-colour("black");

--- a/app/views/includes/related-nav-list.html
+++ b/app/views/includes/related-nav-list.html
@@ -1,21 +1,21 @@
 {% macro list(options) %}
   <ul class="gem-c-related-navigation__link-list">
     {% for item in options.items %}
-      {% if loop.index <= 5 or items.length <= 6 %}
+      {% if loop.index <= 3 or items.length <= 4 %}
         <li class="gem-c-related-navigation__link xpl-related-nav__link">
           <a class="govuk-link gem-c-related-navigation__section-link" href="{{ item.base_path }}">{{ item.title }}</a>
         </li>
       {% else %}
-        {% if loop.index == 6 %}
+        {% if loop.index == 4 %}
           <li class="gem-c-related-navigation__link xpl-related-nav__link">
-            <button class="xpl-related-nav__toggle" data-controls="toggle_haha" data-expanded="false" data-toggled-text="Show fewer" data-button="true">
+            <button class="xpl-related-nav__toggle" data-controls="toggle_related_nav_{{ options.pluralName }}" data-expanded="false" data-toggled-text="Fewer {{ options.pluralName }}" data-button="true">
               <span class="xpl-related-nav__toggle-chevron xpl-related-nav__toggle-chevron--down js-toggle-button-chevron"></span>
               <span class="xpl-related-nav__toggle-text js-toggle-button-text">More {{ options.pluralName }}</span>
             </button>
           </li>
         {% endif %}
 
-        <li class="gem-c-related-navigation__link xpl-related-nav__link js-hidden" data-toggle-target="toggle_haha">
+        <li class="gem-c-related-navigation__link xpl-related-nav__link js-hidden" data-toggle-target="toggle_related_nav_{{ options.pluralName }}">
           <a class="govuk-link gem-c-related-navigation__section-link" href="{{ item.base_path }}">{{ item.title }}</a>
         </li>
       {% endif %}


### PR DESCRIPTION
## What
Updates the related nav toggle button and function with the following changes:

- Increases space between button and content
- Fixes an issue on `:focus:hover` state
- Changes the opened text to `fewer {section}`
- Reduces the number of items shown before the toggle from 6 to 4

## Why
So that the related nav behaves how we want it to behave before launching our next round of research.

[Test page](https://www.gov.uk/guidance/trader-support-service)

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-09-28 at 16 52 13](https://user-images.githubusercontent.com/64783893/135124029-6539f30c-19ee-4e39-84ae-174ded74c27c.png) | ![Screenshot 2021-09-28 at 16 52 46](https://user-images.githubusercontent.com/64783893/135124069-78be7612-4281-4ad7-a502-fae123c83538.png) |
| ![Screenshot 2021-09-28 at 16 52 20](https://user-images.githubusercontent.com/64783893/135124122-ed46dc46-801f-4982-a99f-95ffa319fe2b.png) | ![Screenshot 2021-09-28 at 16 53 01](https://user-images.githubusercontent.com/64783893/135124170-dd5428c2-e062-4d97-bdce-f7e4191c6817.png) |
| ![Screenshot 2021-09-28 at 16 52 39](https://user-images.githubusercontent.com/64783893/135124240-0c389f5b-638f-42b2-86a8-1e37d2d20a42.png) | ![Screenshot 2021-09-28 at 16 53 17](https://user-images.githubusercontent.com/64783893/135124289-e8f41c77-63d8-4980-9471-0f4e82c44428.png) |
