### PR TITLE
Add html publication template

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -9,7 +9,9 @@ $govuk-assets-path: '/govuk/assets/';
 
 // Patterns that aren't in Frontend
 @import "patterns/contents-list";
+@import "patterns/inverse-header";
 @import "patterns/metadata";
+@import "patterns/org-logo";
 @import "patterns/print-link";
 @import "patterns/published-dates";
 @import "patterns/step-by-step-header";
@@ -335,5 +337,6 @@ img {
 @import "xpl-tabs";
 @import "xpl-cards";
 @import "xpl-breadcrumbs";
+@import "xpl-org-logos";
 @import "xpl-part-of";
 @import "xpl-related-nav";

--- a/app/assets/sass/patterns/_inverse-header.scss
+++ b/app/assets/sass/patterns/_inverse-header.scss
@@ -1,0 +1,30 @@
+.gem-c-inverse-header {
+  width: 100%;
+  background-color: govuk-colour("blue");
+  margin-bottom: govuk-spacing(6);
+  padding: 0 govuk-spacing(6) govuk-spacing(6);
+  box-sizing: border-box;
+
+  h1, p {
+    color: govuk-colour("white");
+  }
+}
+
+.gem-c-inverse-header .gem-c-inverse-header__supplement,
+.gem-c-inverse-header .publication-header__last-changed {
+  // This publication-header class is injected on publication pages, really
+  // it should be a component class or be a component in it's own right.
+  @include govuk-font($size: 16, $line-height: 1.5);
+  color: govuk-colour("white");
+  margin: 0;
+}
+
+.gem-c-inverse-header--full-width {
+  padding-left: 0;
+  padding-right: 0;
+  padding-bottom: govuk-spacing(3);
+}
+
+.gem-c-inverse-header--padding-top {
+  padding-top: govuk-spacing(3);
+}

--- a/app/assets/sass/patterns/_org-logo.scss
+++ b/app/assets/sass/patterns/_org-logo.scss
@@ -1,0 +1,183 @@
+.organisation-logos {
+  list-style-type: none;
+  margin-top: 0;
+  padding: 0;
+
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+}
+
+.organisation-logos__logo {
+  padding-bottom: govuk-spacing(3);
+  margin-right: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    flex-basis: 25%;
+    min-width: 130px;
+  }
+}
+
+// Default logo corresponds with the "medium stacked" Whitehall equivalent
+.gem-c-organisation-logo {
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.35;
+  // When this is a heading the margin needs to be set to stop it from
+  // inheriting the browser's default margin:
+  margin: 0;
+
+  @include govuk-media-query($from: tablet) {
+    font-size: 18px;
+  }
+}
+
+.gem-c-organisation-logo__container {
+  text-transform: none;
+  text-decoration: none;
+  display: block;
+  color: govuk-colour("black");
+  height: auto;
+  width: auto;
+
+  // Logo direction never changes, even for rtl content.
+  direction: ltr;
+}
+
+.gem-c-organisation-logo__container--inline {
+  display: inline-block;
+  padding-right: govuk-spacing(1);
+}
+
+// Scale images on smaller viewports
+.gem-c-organisation-logo__image {
+  max-width: 100%;
+}
+
+.gem-c-organisation-logo__crest {
+  // Default brand colour
+  border-left: 2px solid govuk-colour("black");
+  padding-top: 20px;
+  padding-left: 6px;
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: 25px;
+    padding-left: 7px;
+  }
+
+  .brand--executive-office & {
+    border-left-width: 0;
+    padding-left: 0;
+    background-position: 0 0;
+  }
+}
+
+.gem-c-organisation-logo__name {
+  position: relative;
+  top: 3px;
+  font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
+}
+
+.gem-c-organisation-logo__link {
+  @include govuk-link-common;
+  @include govuk-link-style-text;
+  font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+  }
+
+  &:active {
+    color: govuk-colour("black");
+    @include govuk-link-hover-decoration;
+  }
+
+  &:focus {
+    // Using `@include govuk-focused-text;` would obscure the text. Tweaked
+    // spacing needed to prevent overlap of the text and the focus state's thick
+    // black line.
+    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-colour, 0 8px $govuk-focus-text-colour;
+    text-decoration: none;
+  }
+}
+
+@mixin crest($crest) {
+  background: url("/public/images/org_logos/#{$crest}_13px.png") no-repeat 5px 0;
+  background-size: auto 20px;
+
+  @include govuk-device-pixel-ratio {
+    background-image: url("/public/images/org_logos/#{$crest}_13px_x2.png");
+  }
+
+  @include govuk-media-query($from: tablet) {
+    background: url("/public/images/org_logos/#{$crest}_18px.png") no-repeat 6px 0;
+    background-size: auto 26px;
+
+    @include govuk-device-pixel-ratio {
+      background-image: url("/public/images/org_logos/#{$crest}_18px_x2.png");
+    }
+  }
+}
+
+@mixin tall-crest {
+  padding-top: 25px;
+  background-size: auto 25px;
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: 35px;
+    background-size: auto 34px;
+  }
+}
+
+.gem-c-organisation-logo__crest--dit {
+  @include crest("dit_crest");
+}
+
+.gem-c-organisation-logo__crest--bis {
+  @include crest("bis_crest");
+}
+
+.gem-c-organisation-logo__crest--hmrc {
+  @include crest("hmrc_crest");
+}
+
+.gem-c-organisation-logo__crest--ho {
+  @include crest("ho_crest");
+  @include tall-crest;
+}
+
+.gem-c-organisation-logo__crest--mod {
+  @include crest("mod_crest");
+  @include tall-crest;
+}
+
+.gem-c-organisation-logo__crest--single-identity,
+.gem-c-organisation-logo__crest--eo,
+.gem-c-organisation-logo__crest--org {
+  @include crest("org_crest");
+}
+
+.gem-c-organisation-logo__crest--portcullis {
+  @include crest("portcullis");
+}
+
+.gem-c-organisation-logo__crest--so {
+  @include crest("so_crest");
+}
+
+.gem-c-organisation-logo__crest--ukaea {
+  @include crest("ukaea_crest");
+}
+
+.gem-c-organisation-logo__crest--ukho {
+  @include crest("ukho");
+  @include tall-crest;
+}
+
+.gem-c-organisation-logo__crest--wales {
+  @include crest("wales_crest");
+  @include tall-crest;
+}

--- a/app/assets/sass/xpl-org-logos.scss
+++ b/app/assets/sass/xpl-org-logos.scss
@@ -1,0 +1,5 @@
+.xpl-org-logos {
+  background-color: govuk-colour("light-grey");
+  padding: govuk-spacing(6);
+  margin-bottom: govuk-spacing(6);
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -186,11 +186,12 @@ router.get('/*', function (req,res) {
     const contentType = body.schema_name
     
     if (supportedDocumentTypes.includes(contentType)) {
-      const protoApiUrl = `${API_URL}/generic?slug=${originalUrl}`
+      const isHtmlPub = contentType === 'html_publication'
+      const protoApiUrl = `${API_URL}/generic?slug=${originalUrl}&htmlpub=${isHtmlPub}`
 
       request(protoApiUrl, { json: true }, (error, result, body) => {
         if (error) throw error
-        res.render('generic_template', body)
+        res.render((isHtmlPub ? 'html_publication' : 'generic_template'), body)
       })
     } else {
       request(govUkUrl(req), function (error, response, body) {

--- a/app/views/generic_template.html
+++ b/app/views/generic_template.html
@@ -50,7 +50,7 @@
           <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-8 govuk-!-padding-top-0">{{ title }}</h1>
           <p class="lede govuk-body-l">
             {% if context %}
-            <strong>{{context}}</strong> &mdash;
+              <strong>{{context}}</strong> &mdash;
             {% endif %}
             {{ description }}
           </p>

--- a/app/views/html_publication.html
+++ b/app/views/html_publication.html
@@ -1,0 +1,101 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  {{ title }} - GOV.UK
+{% endblock %}
+
+{% block main %}
+  <main id="content" role="main" class="xpl-detailed-guide">
+    <div class="xpl-breadcrumbs">
+      <div class="govuk-width-container xpl-breadcrumbs__inner govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile">
+        <ol class="govuk-breadcrumbs__list">
+          <li class="xpl-breadcrumbs__list-item govuk-breadcrumbs__list-item">
+            <a class="govuk-breadcrumbs__link xpl-breadcrumbs__link" href="/">Home</a>
+          </li>
+          {% if breadcrumbs %}
+            {% for crumb in breadcrumbs %}
+              <li class="xpl-breadcrumbs__list-item govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link xpl-breadcrumbs__link" href="{{ crumb.base_path }}">{{ crumb.title }}</a>
+              </li>
+            {% endfor %}
+          {% endif %}
+        </ol>
+      </div>
+    </div>
+
+    <div class="govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <div class="xpl-part-of">
+            <span class="xpl-part-of__label">Part of</span>
+            <a href="{{ part_of_parent.base_path }}" class="xpl-part-of__link govuk-link">
+              {{ part_of_parent.title }}
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <div class="gem-c-inverse-header gem-c-inverse-header--padding-top govuk-!-margin-bottom-0">
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-three-quarters">
+                <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">{{ title }}</h1>
+                <p class="lede govuk-body-l govuk-!-margin-bottom-4">
+                  {% if context %}
+                    <strong>{{context}}</strong>
+                  {% endif %}
+                </p>
+                <p class="govuk-body-l govuk-!-margin-bottom-4">
+                  Published {{ metadata.first_published }}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <div class="xpl-org-logos">
+            <ul class="organisation-logos">
+              <li class="organisation-logos__logo">      
+                <div class="gem-c-organisation-logo brand--department-for-communities-and-local-government" data-component-name="organisation-logo" data-app-name="gem-c-">
+                    <a class="gem-c-organisation-logo__container gem-c-organisation-logo__link gem-c-organisation-logo__crest gem-c-organisation-logo__crest--single-identity brand__border-color" href="/government/organisations/building-regulations-advisory-committee">
+                      <span class="gem-c-organisation-logo__name">Building Regulations <br>Advisory Committee</span>
+                </a>
+                </div>
+              </li>
+              <li class="organisation-logos__logo">    
+                <div class="gem-c-organisation-logo brand--department-for-communities-and-local-government" data-component-name="organisation-logo" data-app-name="gem-c-">
+                    <a class="gem-c-organisation-logo__container gem-c-organisation-logo__link gem-c-organisation-logo__crest gem-c-organisation-logo__crest--single-identity brand__border-color" href="/government/organisations/ministry-of-housing-communities-and-local-government">
+                      <span class="gem-c-organisation-logo__name">Ministry of Housing,<br>Communities &amp;<br>Local Government</span>
+                </a>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-quarter-from-desktop">
+          {% if contents_list.length %}
+            <nav class="gem-c-contents-list" aria-label="Contents" role="navigation">
+              <h2 class="gem-c-contents-list__title">Contents</h2>
+              <ol class="gem-c-contents-list__list">
+                {% for item in contents_list %}
+                  <li class="gem-c-contents-list__list-item">
+                    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#{{ item.id }}">{{ item.text }}</a>
+                  </li>
+                {% endfor %}
+              </ol>
+            </nav>
+          {% endif %}
+        </div>
+        <div class="govuk-grid-column-three-quarters-from-desktop">
+          <div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">
+            {{ details|safe }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+{% endblock %}


### PR DESCRIPTION
## What
Adds a mock html publication template and routing for that content type with some design tweaks

## Why
So we can test new superbreadcrumb rules in the prototype without disrupting the html publication format.

Relies on https://github.com/alphagov/govuk-explore-api-prototype/pull/17

[Card](https://trello.com/c/ItaWLeoI/537-test-and-refine-worked-out-content-types-for-page-level-nav-prototype)
[Test page](https://www.gov.uk/government/publications/building-regulations-advisory-committee-golden-thread-report/building-regulations-advisory-committee-golden-thread-report)

## Visual changes

| Before | After |
| --- | --- |
| ![www gov uk_government_publications_building-regulations-advisory-committee-golden-thread-report_building-regulations-advisory-committee-golden-thread-report](https://user-images.githubusercontent.com/64783893/135871459-04c1f2aa-da42-4d06-99ab-dded51c35d76.png) | ![localhost_3000_government_publications_building-regulations-advisory-committee-golden-thread-report_building-regulations-advisory-committee-golden-thread-report](https://user-images.githubusercontent.com/64783893/135871482-179da8c5-8912-49b1-8c78-6ba2b2f8d030.png) |