### PR TITLE
Add necessary elements for collection document types

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -9,6 +9,7 @@ $govuk-assets-path: '/govuk/assets/';
 
 // Patterns that aren't in Frontend
 @import "patterns/contents-list";
+@import "patterns/documents-list";
 @import "patterns/inverse-header";
 @import "patterns/metadata";
 @import "patterns/org-logo";

--- a/app/assets/sass/patterns/_documents-list.scss
+++ b/app/assets/sass/patterns/_documents-list.scss
@@ -1,0 +1,176 @@
+.gem-c-document-list {
+  @include govuk-text-colour;
+  @include govuk-font(19);
+  margin: 0;
+  padding: 0;
+}
+
+.gem-c-document-list__item {
+  margin-bottom: govuk-spacing(5);
+  padding-top: govuk-spacing(2);
+  border-top: 1px solid $govuk-border-colour;
+  list-style: none;
+}
+
+.gem-c-document-list__item-title {
+  @include govuk-font($size: 19, $weight: bold);
+  display: inline-block;
+}
+
+.gem-c-document-list--no-underline {
+  .gem-c-document-list__item-title {
+    text-decoration: none;
+  }
+}
+
+.gem-c-document-list--no-top-border {
+  .gem-c-document-list__item {
+    border-top: none;
+  }
+}
+
+.gem-c-document-list__item-title--context {
+  margin-right: govuk-spacing(2);
+
+  .direction-rtl & {
+    margin-right: 0;
+    margin-left: govuk-spacing(2);
+  }
+}
+
+.gem-c-document-list__item-context {
+  color: govuk-colour("dark-grey", $legacy: "grey-1");
+}
+
+.gem-c-document-list__item-description {
+  @include govuk-text-colour;
+  margin: govuk-spacing(1) 0;
+}
+
+.gem-c-document-list__subtext {
+  margin: 0;
+}
+
+.gem-c-document-list__item-description,
+.gem-c-document-list__subtext {
+  @include govuk-font($size: 16, $line-height: 1.5);
+}
+
+.gem-c-document-list__item-description--full-size {
+  @include govuk-font($size: 19);
+}
+
+.gem-c-document-list__item-metadata {
+  padding: 0;
+}
+
+.gem-c-document-list__attribute {
+  @include govuk-text-colour;
+  @include govuk-font(14);
+  display: inline-block;
+  list-style: none;
+  padding-right: govuk-spacing(4);
+
+  .direction-rtl & {
+    padding-right: 0;
+    padding-left: govuk-spacing(4);
+  }
+}
+
+.gem-c-document-list--bottom-margin {
+  margin-bottom: govuk-spacing(4);
+}
+
+.gem-c-document-list--top-margin {
+  margin-top: govuk-spacing(4);
+}
+
+.gem-c-document-list__multi-list {
+  width: 100%;
+  margin-right: 25px;
+}
+
+.gem-c-document-list__item--highlight {
+  border: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+  padding: govuk-spacing(6);
+  margin-bottom: govuk-spacing(6);
+
+  .gem-c-document-list__item-title {
+    @include govuk-font(24, bold);
+  }
+}
+
+.gem-c-document-list__highlight-text {
+  @include govuk-font(16, bold);
+  margin: 0 0 govuk-spacing(3) 0;
+}
+
+.gem-c-document-list__children {
+  margin-bottom: 0;
+  padding-left: 0;
+  list-style-type: none;
+
+  @include govuk-media-query($from: desktop) {
+    margin-left: govuk-spacing(4);
+    margin-top: govuk-spacing(4);
+
+    @supports (display: grid) {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      column-gap: govuk-spacing(3);
+    }
+  }
+}
+
+.gem-c-document-list-child {
+  @include govuk-font($size: 16);
+  position: relative;
+  padding-left: govuk-spacing(5);
+  padding-top: govuk-spacing(2);
+
+  &:before {
+    content: "—";
+    position: absolute;
+    left: 0;
+    overflow: hidden;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    padding: 0;
+    padding-bottom: govuk-spacing(2);
+
+    &:before {
+      display: none;
+    }
+  }
+}
+
+.gem-c-document-list-child__heading {
+  @include govuk-media-query($from: tablet) {
+    @include govuk-typography-weight-bold;
+  }
+}
+
+.gem-c-document-list-child__link {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    text-underline-offset: .1em;
+    @include govuk-link-hover-decoration;
+  }
+
+  &:focus {
+    text-decoration: none;
+  }
+}
+
+.gem-c-document-list-child__description {
+  @include govuk-text-colour;
+  margin-top: govuk-spacing(1);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($until: tablet) {
+    display: none;
+  }
+}


### PR DESCRIPTION
## What/Why
Adds elements necessary for collection document types on the prototype. We're doing this because the topic we want to test includes collections and this will allow them to render the necessary data for the prototype to not feel jarring to users.

[Test page](https://www.gov.uk/government/collections/approved-documents)
[Card](https://trello.com/c/ItaWLeoI/537-test-and-refine-worked-out-content-types-for-page-level-nav-prototype)