### PR TITLE
Add visual elements for consultation content type

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -8,6 +8,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "lib/extensions/extensions";
 
 // Patterns that aren't in Frontend
+@import "patterns/banner";
 @import "patterns/contents-list";
 @import "patterns/inverse-header";
 @import "patterns/metadata";

--- a/app/assets/sass/patterns/_banner.scss
+++ b/app/assets/sass/patterns/_banner.scss
@@ -1,0 +1,40 @@
+.app-c-banner {
+  @include govuk-font(19);
+  direction: ltr;
+  background: $govuk-brand-colour;
+  color: govuk-colour("white");
+  padding: govuk-spacing(3);
+  clear: both;
+  margin-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(4) govuk-spacing(6);
+    margin-bottom: govuk-spacing(8);
+  }
+}
+
+.app-c-banner--aside {
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(6);
+  }
+}
+
+.app-c-banner__text {
+  @include govuk-font(24);
+}
+
+.app-c-banner__title {
+  @include govuk-font(27, $weight: bold);
+  margin-bottom: govuk-spacing(2);
+}
+
+.app-c-banner__desc {
+  @include govuk-font(19);
+  color: govuk-colour("white");
+  max-width: 30em;
+  padding-top: govuk-spacing(2);
+}
+
+.consultation-date {
+  font-weight: bold;
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -171,6 +171,7 @@ const govUkUrl = function (req) {
 
 router.get('/*', function (req,res) {
   const supportedDocumentTypes = [
+    'consultation',
     'detailed_guide',
     'document_collection',
     'guide',

--- a/app/views/generic_template.html
+++ b/app/views/generic_template.html
@@ -50,9 +50,14 @@
           <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-8 govuk-!-padding-top-0">{{ title }}</h1>
           <p class="lede govuk-body-l">
             {% if context %}
-              <strong>{{context}}</strong> &mdash;
+              <strong>{{context}}</strong>
+              {% if not is_consultation %}
+                &mdash;
+              {% endif %}
             {% endif %}
-            {{ description }}
+            {% if not is_consultation %}
+              {{ description }}
+            {% endif %}
           </p>
         </div>
       </div>
@@ -95,6 +100,35 @@
               </ol>
             </nav>
           {% endif %}
+
+          {% if is_consultation %}
+            <section class="govuk-notification-banner gem-c-notice govuk-!-margin-bottom-0" aria-label="Notice" role="region">
+              <div class="govuk-notification-banner__content">
+                <h2 class="gem-c-notice__title govuk-notification-banner__heading">We are analysing your feedback</h2>
+                <p class="gem-c-notice__description">
+                  Visit this page again soon to download the outcome to this public&nbsp;feedback.
+                </p>   
+              </div>
+            </section>
+            <section class="app-c-banner app-c-banner--aside" aria-label="Notice" lang="en">
+              <h2 class="app-c-banner__title">Summary</h2>
+              <p class="app-c-banner__desc">
+                {{ description }}
+              </p>
+              <p class="app-c-banner__desc">
+                This consultation ran from<br>
+                <span class="consultation-date">
+                  <time datetime="{{opening_date_time}}">{{opening_date_time_display}}</time> to
+                  <time datetime="{{closing_date_time}}">{{closing_date_time_display}}</time>
+                </span>
+              </p>
+            </section>
+
+            <h2 class="gem-c-heading gem-c-heading--font-size-27 gem-c-heading--mobile-top-margin">Consultation description</h2>
+            <div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">
+              {{ details|safe }}
+            </div>
+          {% endif %}
             
           {% if documents %}
             <h2 class="gem-c-heading gem-c-heading--font-size-27 gem-c-heading--mobile-top-margin">Documents</h2>
@@ -110,7 +144,7 @@
                 {{ item.body|safe }}
               </div>
             {% endfor %}
-          {% else %}
+          {% elif not is_consultation %}
             {% if documents %}
               <h2 class="gem-c-heading gem-c-heading--font-size-27 gem-c-heading--mobile-top-margin">Details</h2>
             {% endif %}


### PR DESCRIPTION
## What/Why
Adds necessary bits for consultation content types so that we can reliably use consultation pages in the next round of research.

[Test page](https://gov.uk/government/consultations/domestic-smoke-and-carbon-monoxide-alarms)

[Card](https://trello.com/c/ItaWLeoI/537-test-and-refine-worked-out-content-types-for-page-level-nav-prototype)

Relies on https://github.com/alphagov/govuk-explore-api-prototype/pull/22