### PR TITLE
Fix prototype on gulp-sass 5+

### DIFF
--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -6,7 +6,7 @@
 */
 
 const gulp = require('gulp')
-const sass = require('gulp-sass')
+const sass = require('gulp-sass')(require('node-sass'))
 const sourcemaps = require('gulp-sourcemaps')
 const path = require('path')
 const fs = require('fs')


### PR DESCRIPTION
This iss the recommended implementation of gulp-sass 5+. The error message from trying to start the prototype without this:

```
gulp-sass 5 does not have a default Sass compiler; please set one yourself.
Both the `sass` and `node-sass` packages are permitted.
For example, in your gulpfile:

  var sass = require('gulp-sass')(require('sass'));
```