### PR TITLE
Revert "Bump node-sass from 4.14.1 to 6.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "glob": "^7.1.4",
     "jest": "^27.2.4",
-    "node-sass": "^6.0.1",
+    "node-sass": "^4.14.1",
     "standard": "^14.3.3",
     "supertest": "^4.0.2"
   }


### PR DESCRIPTION
Reverts alphagov/explore-prototype-4#38