### PR TITLE
Update content lists to account for split guides

### DIFF
--- a/app/views/generic_template.html
+++ b/app/views/generic_template.html
@@ -48,17 +48,19 @@
           {% endif %}
 
           <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-8 govuk-!-padding-top-0">{{ title }}</h1>
-          <p class="lede govuk-body-l">
-            {% if context %}
-              <strong>{{context}}</strong>
-              {% if not is_consultation %}
-                &mdash;
+          {% if not is_mainstream_guide %}
+            <p class="lede govuk-body-l">
+              {% if context %}
+                <strong>{{context}}</strong>
+                {% if not is_consultation %}
+                  &mdash;
+                {% endif %}
               {% endif %}
-            {% endif %}
-            {% if not is_consultation %}
-              {{ description }}
-            {% endif %}
-          </p>
+              {% if not is_consultation %}
+                {{ description }}
+              {% endif %}
+            </p>
+          {% endif %}
         </div>
       </div>
       
@@ -94,7 +96,13 @@
               <ol class="gem-c-contents-list__list">
                 {% for item in contents_list %}
                   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-                    <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#{{ item.id }}">{{ item.text }}</a>
+                    {% if item.id %}
+                      <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#{{ item.id }}">{{ item.text }}</a>
+                    {% elif item.is_current_page %}
+                      {{ item.text }}
+                    {% else %}
+                      <a class="gem-c-contents-list__link govuk-link govuk-link" href="{{ item.slug }}">{{ item.text }}</a>
+                    {% endif %}
                   </li>
                 {% endfor %}
               </ol>
@@ -148,7 +156,7 @@
             {% if documents %}
               <h2 class="gem-c-heading gem-c-heading--font-size-27 gem-c-heading--mobile-top-margin">Details</h2>
             {% endif %}
-            
+
             <div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">
               {{ details|safe }}
             </div>


### PR DESCRIPTION
## What/Why
Add functionality for splitting guides by section, as is on live. This is to resolve an issue with the specific content we're using for user testing as the content is written in such a way that the anchor link setup feels potentially jarring.

Test page https://www.gov.uk/party-walls-building-works

Relies on https://github.com/alphagov/govuk-explore-api-prototype/pull/25