### PR TITLE
Add detailed guidance section on browse suptopics pages

### DIFF
--- a/app/views/sub_topic.html
+++ b/app/views/sub_topic.html
@@ -60,6 +60,15 @@
               </ul>
             {% endif %}
 
+            {% if detailed_guidance %}
+              <h2 class="govuk-heading-m">Detailed guidance</h2>
+              <ul class="govuk-list xpl-subsubtopics">
+                {% for guidance in detailed_guidance %}
+                  <li><a href="{{ guidance.base_path }}">{{ guidance.title }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+
             {% if related_topics|length > 0 %}
               <h2 class="govuk-heading-m">Related topics</h2>
               <div class="topic-tags">


### PR DESCRIPTION
## What/Why
Add a detailed guidance section on browse suptopic pages so that during the research, users are able to more easily switch between mainstream and whitehall content.

Test page: https://www.gov.uk/browse/housing-local-services/planning-permission

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-10-18 at 07 51 17](https://user-images.githubusercontent.com/64783893/137682427-f293cf3c-1a62-452a-b8d7-6908ee79a779.png) | ![Screenshot 2021-10-18 at 07 50 35](https://user-images.githubusercontent.com/64783893/137682341-13581309-ee0c-487c-ad0a-384381f13023.png) | 