### PR TITLE
Update navigation header with new menu functionality

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1961,61 +1961,6 @@ ErrorSummary.prototype.getAssociatedLegendOrLabel = function ($input) {
     $input.closest('label')
 };
 
-function Header ($module) {
-  this.$module = $module;
-}
-
-Header.prototype.init = function () {
-  // Check for module
-  var $module = this.$module;
-  if (!$module) {
-    return
-  }
-
-  // Check for button
-  var $toggleButton = $module.querySelector('.govuk-js-header-toggle');
-  if (!$toggleButton) {
-    return
-  }
-
-  // Handle $toggleButton click events
-//  $toggleButton.addEventListener('click', this.handleClick.bind(this));
-};
-
-/**
-* Toggle class
-* @param {object} node element
-* @param {string} className to toggle
-*/
-Header.prototype.toggleClass = function (node, className) {
-  if (node.className.indexOf(className) > 0) {
-    node.className = node.className.replace(' ' + className, '');
-  } else {
-    node.className += ' ' + className;
-  }
-};
-
-/**
-* An event handler for click event on $toggleButton
-* @param {object} event event
-*/
-
-
-Header.prototype.handleClick = function (event) {
-  var $module = this.$module;
-  var $toggleButton = event.target || event.srcElement;
-  var $target = $module.querySelector('#' + $toggleButton.getAttribute('aria-controls'));
-
-  // If a button with aria-controls, handle click
-  if ($toggleButton && $target) {
-    this.toggleClass($target, 'govuk-header__navigation--open');
-    this.toggleClass($toggleButton, 'govuk-header__menu-button--open');
-    $toggleButton.setAttribute('aria-expanded', $toggleButton.getAttribute('aria-expanded') !== 'true');
-    $target.setAttribute('aria-hidden', $target.getAttribute('aria-hidden') === 'false');
-  }
-};
-
-
 function Radios ($module) {
   this.$module = $module;
   this.$inputs = $module.querySelectorAll('input[type="radio"]');
@@ -2208,10 +2153,6 @@ function initAll (options) {
   var $errorSummary = scope.querySelector('[data-module="govuk-error-summary"]');
   new ErrorSummary($errorSummary).init();
 
-  // Find first header module to enhance.
-  var $toggleButton = scope.querySelector('[data-module="govuk-header"]');
-  new Header($toggleButton).init();
-
   var $radios = scope.querySelectorAll('[data-module="govuk-radios"]');
   nodeListForEach($radios, function ($radio) {
     new Radios($radio).init();
@@ -2225,7 +2166,6 @@ exports.Details = Details;
 exports.CharacterCount = CharacterCount;
 exports.Checkboxes = Checkboxes;
 exports.ErrorSummary = ErrorSummary;
-exports.Header = Header;
 exports.Radios = Radios;
 
 })));

--- a/app/assets/javascripts/explore-header.js
+++ b/app/assets/javascripts/explore-header.js
@@ -1,133 +1,261 @@
-/* global $ */
+//= require govuk/vendor/polyfills/Element/prototype/classList.js
 
-// Desktop: when the Topics header button is clicked
-$('#xpl-topics-menu-item, #xpl-topics-button-desktop').on('click', event => {
-  event.stopPropagation();
-  const menuLabel = $('#xpl-topics-button-desktop');
-  if (menuLabel.parent().hasClass('menu-item-open')) {
-    menuLabel.closest('ul').children('li').removeClass('menu-item-open');
-    $('.xpl-backdrop').hide();
-  } else {
-    menuLabel.closest('ul').children('li').removeClass('menu-item-open');
-    menuLabel.parent('li').addClass('menu-item-open');
-    $('.xpl-backdrop').show();
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  var SETTINGS = {
+    breakpoint: {
+      desktop: 769
+    },
+    label: {
+      hide: 'data-text-for-hide',
+      show: 'data-text-for-show'
+    }
   }
-  $('#xpl-frame2-topics').toggle();
-  $('#xpl-frame2-search').hide();
-  $('#xpl-frame2-activity').hide();
-});
 
-// Desktop: when the Government activity header button is clicked
-$('#xpl-activity-menu-item, #xpl-activity-button-desktop').on('click', event => {
-  event.stopPropagation();
-  const menuLabel = $('#xpl-activity-button-desktop');
-  if (menuLabel.parent().hasClass('menu-item-open')) {
-    menuLabel.closest('ul').children('li').removeClass('menu-item-open');
-    $('.xpl-backdrop').hide();
-  } else {
-    menuLabel.closest('ul').children('li').removeClass('menu-item-open');
-    menuLabel.parent('li').addClass('menu-item-open');
-    $('.xpl-backdrop').show();
+  // Small helpers that update the label when the state of the button has
+  // changed:
+  var setLabel = function ($button, showOrHide) {
+    var newLabel = $button.getAttribute(SETTINGS.label[showOrHide])
+
+    if (newLabel) {
+      $button.setAttribute('aria-label', newLabel)
+    }
   }
-  $('#xpl-frame2-topics').hide();
-  $('#xpl-frame2-search').hide();
-  $('#xpl-frame2-activity').toggle();
-});
 
-// Desktop: when the Search header button is clicked
-$('#xpl-search-menu-item, #xpl-search-button-desktop').on('click', event => {
-  event.stopPropagation();
-  const menuLabel = $('#xpl-search-button-desktop');
-  if (menuLabel.parent().hasClass('menu-item-open')) {
-    menuLabel.closest('ul').children('li').removeClass('menu-item-open');
-    $('.xpl-backdrop').hide();
-  } else {
-    menuLabel.closest('ul').children('li').removeClass('menu-item-open');
-    menuLabel.parent('li').addClass('menu-item-open');
-    $('.xpl-backdrop').show();
+  // Wrapper functions to contain all of the mechanisms needed for hiding and
+  // toggling the menus.
+  var hide = function ($button, $menu) {
+    $button.setAttribute('aria-expanded', false)
+    $button.classList.remove('gem-c-layout-super-navigation-header__open-button')
+    $menu.setAttribute('hidden', 'hidden')
+    setLabel($button, 'show')
   }
-  $('#xpl-frame2-topics').hide();
-  $('#xpl-frame2-activity').hide();
-  $('#xpl-frame2-search').toggle();
-});
-
-
-
-
-// Mobile -- button to show or hide the menu
-document.getElementById('xpl-menu-button').addEventListener('click', event => {
-
-  // change the button itself
-  event.target.classList.toggle('govuk-header__menu-button--open');
-  event.target.innerText = event.target.classList.contains('govuk-header__menu-button--open') ? '×' : 'Menu';
-
-  // show or hide the dropdown
-  $('.explore-header #xpl-popup-menu').toggle();
-
-  if ($('#xpl-search-button').hasClass('govuk-header__menu-button--open')) {
-    // hide the search popup
-    $('#xpl-search-button').removeClass('govuk-header__menu-button--open');
-    $('#xpl-search-button').text('Search');
-    $('#xpl-popup-search').hide();
-  } else {
-    // hide or show the rest of the page
-    $('.explore-header').nextAll().toggle();
+  var show = function ($button, $menu) {
+    $button.setAttribute('aria-expanded', true)
+    $button.classList.add('gem-c-layout-super-navigation-header__open-button')
+    $menu.removeAttribute('hidden')
+    setLabel($button, 'hide')
   }
-});
 
+  var toggle = function ($button, $menu) {
+    var isOpen = $button.getAttribute('aria-expanded') === 'true'
+    var trackingLabel = $button.getAttribute('data-tracking-key')
+    if (isOpen) {
+      hide($button, $menu)
+    } else {
+      show($button, $menu)
+    }
 
-// Mobile -- button to show or hide the search panel
-document.getElementById('xpl-search-button').addEventListener('click', event => {
-  // change the button itself
-  event.target.classList.toggle('govuk-header__menu-button--open');
-  event.target.innerText = event.target.classList.contains('govuk-header__menu-button--open') ? '×' : 'Search';
-
-  // show or hide the dropdown
-  $('.explore-header #xpl-popup-search').toggle();
-
-  // hide or show the rest of the page
-  $('.explore-header').prevAll().toggle();
-
-  if ($('#xpl-menu-button').hasClass('govuk-header__menu-button--open')) {
-    $('#xpl-menu-button').removeClass('govuk-header__menu-button--open');
-    $('#xpl-menu-button').text('Menu');
-    $('#xpl-popup-menu').hide();
-  } else {
-    $('.explore-header').nextAll().toggle();
+    // Fire analytics if analytics are available
+    if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent && trackingLabel) {
+      window.GOVUK.analytics.trackEvent('headerClicked', trackingLabel + (isOpen ? 'Closed' : 'Opened'), { label: 'none' })
+    }
   }
-});
 
+  // Clicking an element inside a `button` element causes the `event.target` to
+  // be the inside element, not the button. This can be taken care of by setting
+  // the CSS pointer-events to be none, but that doesn't work for older
+  // browsers, won't work for people with CSS turned off, or for people who are
+  // using CSS overrides.
+  //    This checks if the $element is the `elementType`; if it is, it gets
+  // returned; if not it recursively checks to see if the parent element is a
+  // `elementType`. This means that it can be used with `pointer-events: none`.
+  var closestParentIncluding = function ($element, elementType) {
+    if ($element.tagName.toLowerCase() === elementType.toLowerCase()) {
+      return $element
+    }
+    return closestParentIncluding($element.parentNode, elementType)
+  }
 
-$('.xpl-backdrop').on('click', function() {
-  $(this).hide();
-  $('.xpl-frame2').hide();
-  $('#navigation-desktop li').removeClass('menu-item-open');
-});
+  // Searched the previous elements to find one with the same tag as set in
+  // `elementType` . If it's found the element is returned; if not, it returns
+  // null.
+  var closestPrevious = function ($element, elementType) {
+    if ($element === null) {
+      return null
+    }
 
+    // Using `previousSibling` means that there is a possibility that the
+    // $element could be a text node or a comment node - checking the `nodeType`
+    // of the element will ensure that it's a real element.
+    if ($element.nodeType === 1 && $element.tagName.toLowerCase() === elementType.toLowerCase()) {
+      return $element
+    }
 
-const cookieBanners = [
-  document.getElementById('global-cookie-message'),
-  document.querySelector('.app-cookie-banner')
-];
-cookieBanners.forEach(banner => banner && banner.parentNode.removeChild(banner));
+    // If `previousElementSibling` can be used then let's use it as it'll be
+    // slightly faster since it skips things that aren't elements. If not,
+    // `previousSibling` can still be used as there's a `nodeType` check.
+    var previousElement = $element.previousElementSibling || $element.previousSibling
 
+    return closestPrevious(previousElement, elementType)
+  }
 
-document.addEventListener('DOMContentLoaded', () => {
-  $('#xpl-topics-button-desktop').replaceWith(`
-    <button id="xpl-topics-button-desktop" class="xpl-menu__button">
-      Topics
-    </button>
- `);
+  // When moving from one screen size to another (eg mobile to desktop) we need
+  // to find out whether a submenu is open so the parent menu can be kept open.
+  var hasSubMenusOpen = function ($menu) {
+    return $menu.querySelectorAll('button[aria-expanded="true"]').length > 0
+  }
 
-  $('#xpl-activity-button-desktop').replaceWith(`
-    <button id="xpl-activity-button-desktop" class="xpl-menu__button">
-       Government activity
-    </button>
-  `);
+  // Returns what screen size the window is currently. Returns a string of
+  // either `desktop` or `mobile` so it can be interpolated to access the
+  // `data-toggle-{desktop|mobile}-group` attribute.
+  var windowSize = function () {
+    return window.innerWidth >= SETTINGS.breakpoint.desktop ? 'desktop' : 'mobile'
+  }
 
-  $('#xpl-search-button-desktop').replaceWith(`
-    <button id="xpl-search-button-desktop" class="xpl-menu__button xpl-search-button">Search</button>
-  `);
+  function Header ($module) {
+    this.$module = $module
+    this.$navigationToggle = this.$module.querySelector('#super-navigation-menu-toggle')
+    this.$navigationMenu = this.$module.querySelector('#super-navigation-menu')
+    this.$searchToggle = this.$module.querySelector('#super-search-menu-toggle')
+    this.$searchMenu = this.$module.querySelector('#super-search-menu')
 
+    // The menu toggler buttons need three attributes for this to work:
+    //  - `aria-controls` contains the id of the menu to be toggled
+    //  - `data-toggle-mobile-group` is the group that the menu belongs to on
+    //    smaller screens
+    //  - `data-toggle-desktop-group` is the group that the menu belongs to on
+    //    larger screens
+    this.$buttons = this.$module.querySelectorAll(
+      'button[aria-controls][data-toggle-mobile-group][data-toggle-desktop-group]'
+    )
 
-});
+    this.hiddenButtons = this.$module.querySelectorAll('button[hidden]')
+
+    this.lastWindowSize = undefined
+  }
+
+  Header.prototype.windowSize = windowSize
+
+  // Resizes the space needed for the dropdown menu so that it doesn't overlap
+  // with the page content. As this is an event that needs to be added and
+  // removed it can't be be bound to `this` because that changes the fingerprint
+  // of the function, and makes it unable to be removed with
+  // `removeEventListener`.
+  Header.prototype.resizeHandler = function () {
+    var $module = document.querySelector('[data-module="govuk-header"]')
+    var $openButton = $module.querySelector('[aria-expanded="true"][data-toggle-desktop-group="top"]')
+    var $openMenu = $openButton ? $module.querySelector('#' + $openButton.getAttribute('aria-controls')) : null
+    var margin = $openMenu && windowSize() === 'desktop' ? $openMenu.offsetHeight : 0
+
+    $module.style.marginBottom = margin + 'px'
+  }
+
+  Header.prototype.updateStates = function () {
+    if (this.windowSize() === 'mobile' && this.lastWindowSize !== 'mobile') {
+      this.$navigationToggle.removeAttribute('hidden')
+
+      // Hides navigation menu unless a submenu is open - this could be common
+      // as the desktop view has the navigation submenu as top level in the
+      // menu.
+      if (!hasSubMenusOpen(this.$navigationMenu)) {
+        hide(this.$navigationToggle, this.$navigationMenu)
+      }
+
+      this.$module.style.marginBottom = '0'
+    }
+
+    // Hide the navigation toggle button and show the navigation submenu:
+    if (this.windowSize() === 'desktop' && this.lastWindowSize !== 'desktop') {
+      this.$navigationToggle.setAttribute('hidden', 'hidden')
+      this.$navigationMenu.removeAttribute('hidden')
+
+      this.resizeHandler()
+    }
+
+    this.lastWindowSize = this.windowSize()
+  }
+
+  Header.prototype.buttonHandler = function (event) {
+    var $target = closestParentIncluding(event.target, 'button')
+    var $targetMenu = this.$module.querySelector('#' + $target.getAttribute('aria-controls'))
+
+    var toggleGroupAttribute = 'data-toggle-' + this.windowSize() + '-group'
+    var toggleGroupName = $target.getAttribute(toggleGroupAttribute)
+    var toggleGroupList = this.$module.querySelectorAll('[' + toggleGroupAttribute + '="' + toggleGroupName + '"]')
+
+    for (var k = 0; k < toggleGroupList.length; k++) {
+      var $element = toggleGroupList[k]
+      if ($element !== $target) {
+        var $menu = this.$module.querySelector('#' + $element.getAttribute('aria-controls'))
+        hide($element, $menu)
+      }
+    }
+
+    toggle($target, $targetMenu)
+
+    if (this.windowSize() === 'desktop') {
+      this.$module.style.marginBottom = $targetMenu.offsetHeight + 'px'
+    }
+  }
+
+  Header.prototype.init = function () {
+    for (var j = 0; j < this.$buttons.length; j++) {
+      var $button = this.$buttons[j]
+      $button.addEventListener('click', this.buttonHandler.bind(this), true)
+    }
+
+    // The toggle buttons are hardcoded to be hidden in the markup - this means
+    // that people without JavaScript turned on won't have buttons present that
+    // don't do anything.
+    //     Since JavaScript is enabled we can remove the hidden attribute from
+    // the buttons so that they're perceivable by users.
+    //     As the toggle buttons are now selectable, we should prevent the links
+    // from being selectable to avoid confusion.
+    for (var i = 0; i < this.hiddenButtons.length; i++) {
+      var $element = this.hiddenButtons[i]
+      $element.removeAttribute('hidden')
+
+      var closestSiblingLink = closestPrevious($element, 'a')
+      if (closestSiblingLink) {
+        closestSiblingLink.setAttribute('hidden', 'hidden')
+      }
+    }
+
+    this.$module.querySelector('.gem-c-layout-super-navigation-header__search-item-link')
+      .setAttribute('hidden', 'hidden')
+
+    // Navigation menu and search menu are hardcoded to be open in the markup -
+    // this means that the menu still makes sense with CSS and JavaScript turned
+    // off.
+    //     The menus now need to be hidden as part of the JavaScript
+    // initialisation.
+    //   - On both mobile and desktop, this means hiding the search menu
+    //   - On mobile, this means hiding the navigation
+    //   - On desktop, this means hiding the navigation button, showing the
+    //     second level navigation menu
+    hide(this.$searchToggle, this.$searchMenu)
+    this.updateStates()
+
+    this.lastWindowSize = this.windowSize()
+
+    // The menu needs to be updated when the window is resized - specifically,
+    // the top level navigation toggle needs to be shown or hidden.
+    //     Using `matchMedia` to listen for both resize events means that this
+    // will only fire when the media query is matched so is more efficient. The
+    // fallback is the `window.resize` event with a check to make sure that it
+    // only does things when moving from mobile to desktop view.
+    var setupResizeListener = function () {
+      window.addEventListener('resize', this.updateStates.bind(this), { passive: true })
+    }.bind(this)
+
+    if (typeof window.matchMedia === 'function') {
+      // Internet Explorer 11 supports `matchMedia`, but doesn't support
+      // the `change` event[1] - so we try it, and then fail back to using
+      // `window.resize`.
+      // [1]: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/onchange
+      try {
+        window.matchMedia('screen and (min-width:' + SETTINGS.breakpoint.desktop + 'px)')
+          .addEventListener('change', this.updateStates.bind(this))
+      } catch (error) {
+        setupResizeListener()
+      }
+    } else {
+      setupResizeListener()
+    }
+  }
+
+  Modules.Header = Header
+})(window.GOVUK.Modules)

--- a/app/assets/sass/explore-header.scss
+++ b/app/assets/sass/explore-header.scss
@@ -1,971 +1,813 @@
-@import "media-queries";
-@import "sass-mq";
-@import "colour";
-@import "xpl-link-styles";
+/// Set grid row or column value using the fraction unit.
+///
+/// @param {Integer} $number - number of fractions that the grid row or column
+///   needs to be divided into.
+/// @returns {String} - the value
+///
+/// @example scss - Five fractions will return `1fr 1fr 1fr 1fr 1fr`.
+///  .container {
+///    grid-template-rows: fractions(5);
+///  }
+///
+@function fractions($number) {
+  $fractions: "1fr";
 
+  @for $i from 1 to $number {
+    $fractions: $fractions + " 1fr";
+  }
 
-$govuk-link-colour: govuk-colour("blue") !default;
-$govuk-border-colour: govuk-colour("mid-grey");
-$link-hover-colour: #003078;
-$menu-hover-colour: #005ff8;
-
-$govuk-link-underline-thickness: 0.0625rem !default;
-$govuk-heavy-link-underline-thickness: 3px;
-$govuk-link-hover-underline-thickness: unquote("max(.1875rem, .12em)") !default;
-$govuk-link-underline-offset: 0.15em !default;
-$govuk-text-colour: govuk-colour("black") !default;
-
-$mobile-width: 360px;
-$tablet-width: 740px;
-$desktop-width: 768px;
-$wide-width: 1300px;
-$font: "GDS Transport", nta, Arial, sans-serif;
-
-/*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */
-/* stylelint-disable-line scss/comment-no-loud  */
-@font-face {
-  font-family: "GDS Transport";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/govuk/assets/fonts/light-94a07e06a1-v2.woff2") format("woff2"), url("/govuk/assets/fonts/light-f591b13f7d-v2.woff") format("woff");
-  font-display: fallback;
+  @return unquote($fractions);
 }
 
-@font-face {
-  font-family: "GDS Transport";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/govuk/assets/fonts/bold-b542beb274-v2.woff2") format("woff2"), url("/govuk/assets/fonts/bold-affa96571d-v2.woff") format("woff");
-  font-display: fallback;
-}
+/// Arrange items into vertical columns
+///
+/// @param {Integer} $items - number of items that need to be arranged
+/// @param {Integer} $columns - number of columns required
+/// @param {String} $selector - (optional) the inner element to be targeted.
+///
+/// @example scss - A 7 item 2 column layout.
+///  .container {
+///    @include columns(7, 2);
+///  }
 
-@media print {
-  .govuk-link, a, .app-step-nav-header__title, .app-step-nav-related__link {
-    font-family: sans-serif;
-  }
-}
+/// @example scss - A 9 item 3 column layout that has `div`s as the inner
+///   elements.
+///  .container {
+///    @include columns(9, 3, "div");
+///  }
+///
+@mixin columns($items, $columns, $selector: "*") {
+  $rows: ceil($items / $columns);
 
-//---- menu ----
-.explore-header {
-  border-bottom: 0;
+  display: -ms-grid;
+  display: grid;
+  grid-auto-flow: column;
+  -ms-grid-columns: fractions($columns);
+  grid-template-columns: fractions($columns);
+  -ms-grid-rows: fractions($rows);
+  grid-template-rows: fractions($rows);
 
-  button { font-family: inherit; }
+  // Internet Explorer 10-11 require each element to be placed in the grid -
+  // the `grid-auto-flow` property isn't supported. This means that both the
+  // column and row needs to be set for every element.
 
-  a:link, a:visited {
-    text-decoration: none;
-  }
+  // This creates a list of lists to represent the columns and rows; for
+  // example, a 7 item 2 column list would create this:
+  //   [
+  //     [1, 2, 3, 4 ] // column one
+  //     [5, 6, 7] // column two
+  //   ]
+  $grid: ();
+  $counter: 0;
 
-  &.govuk-header {
-    padding-top: 0;
-  }
+  @for $column from 1 through $columns {
+    $this-row: ();
 
-  .govuk-header__logotype {
-    height: 30px;
-    vertical-align: top;
-  }
+    @for $row from 1 through $rows {
+      $counter: $counter + 1;
 
-  .govuk-header__logo {
-    margin-bottom: 0;
-    padding-bottom: 12px;
-    padding-top: 3px;
-  }
-
-  .govuk-header__container {
-    border-bottom: none;
-    padding: 10px 25px 0 25px;
-    margin-left: 0;
-    margin-right: 0;
-    &--old-page {
-      padding: 10px 15px 0 15px;
+      @if $counter <= $items {
+        $this-row: append($this-row, $counter);
+      }
     }
+
+    $grid: append($grid, $this-row, "comma");
   }
 
-  .govuk-header__link--homepage {
-    height: 30px;
-    font-family: $font;
-  }
+  // Now we can loop through the list of lists to create the rules needed for
+  // the older grid syntax; fist looping through the list to get the number
+  // needed for the column, then looping again to get the number for the grid
+  // row:
+  @for $column_index from 1 through length($grid) {
+    $this-row: nth($grid, $column_index);
 
-  .govuk-header__logo {
-    a {
-      text-decoration: underline;
-      &:hover,
-      &:active {
-        border-bottom: 3px solid;
-        margin-bottom: -3px;
+    @for $item-index from 1 through length($this-row) {
+      $this-item: nth($this-row, $item-index);
+
+      & > #{$selector}:nth-child(#{$this-item}) {
+        -ms-grid-column: $column_index;
+        -ms-grid-row: $item-index;
       }
     }
   }
+}
 
-  .govuk-header__content {
-    padding: 0;
-  }
+$search-icon-size: 20px;
 
-  #xpl-topics-button {
-    padding-left: 0;
-  }
+@mixin chevron($colour) {
+  border-bottom: 3px solid govuk-colour($colour);
+  border-right: 3px solid govuk-colour($colour);
+  content: " ";
+  display: inline-block;
+  height: 8px;
+  margin: 0 8px 0 2px;
+  transform: translateY(-35%) rotate(45deg);
+  vertical-align: middle;
+  width: 8px;
+}
 
-  .xpl-nav--desktop {
-    display: block;
-    background: govuk-colour("black");
-    border-top: 1px solid #6f6e70;
-    a:link {
-      color: govuk-colour("white");
-    }
-  }
+%top-level-navigation-link-base {
+  background: none;
+  @include govuk-font($size: 24, $weight: bold, $line-height: 20px);
+  border: 0;
+  box-sizing: border-box;
+  display: block;
+  margin: 0;
+  padding: govuk-spacing(6) govuk-spacing(3);
+  position: relative;
+  text-decoration: none !important;
 
-  .xpl-frame2 ul {
-    list-style-type: none;
-    padding: 0;
-    li {
-      margin-bottom: 40px;
-      a:link, a:visited {
-        font-weight: bold;
-        font-size: 18px;
-        margin-bottom: 5px;
-        display: inline-block;
-      }
-
-      a:hover {
-        margin-bottom: 3px;
-      }
-    }
-  }
-
-  .govuk-header__navigation, #xpl-search-box {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 960px;
-  }
-
-  .xpl-menu__button {
-    font-family: "GDS Transport", nta, Arial, sans-serif;
-    background: none;
-    border: 0;
-    padding: 0;
-    font-size: 22px;
-    font-weight: bold;
+  &,
+  &:link,
+  &:visited {
     color: $govuk-link-colour;
-    display: block;
   }
 
-  .govuk-header__navigation-item:hover {
-    button:focus {
-      border-bottom: 0;
-      margin-bottom: 0;
-    }
+  &:focus {
+    background: $govuk-focus-colour;
+    border-color: $govuk-focus-text-colour;
+    border-top-color: $govuk-focus-colour;
+    color: $govuk-focus-text-colour;
+    outline: 3px solid transparent;
+    box-shadow: none;
+    z-index: 1;
   }
 
-  .xpl-menu__button-back {
-    border: 0;
-    background: none;
-    &::before {
-      content: "< ";
-    }
-    font-size: 18px;
-    color: #8c8c8c;
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(6);
   }
 
-  #xpl-popup-search, #xpl-popup-menu {
-    margin: 0 -20px 0 -20px;
-    background: govuk-colour("white");
-  }
+  @include govuk-media-query($from: desktop) {
+    @include govuk-font($size: 16, $weight: false, $line-height: 20px);
+    color: govuk-colour("white");
+    display: inherit;
+    height: govuk-spacing(9);
+    padding: govuk-spacing(4);
 
-  #xpl-popup-search {
-    padding: 0 25px 0 25px;
-    height: 100vh;
-    h2 {
-      color: black;
-      margin-top: 0;
-      padding: 40px 0 0 0;
-      margin-bottom: 30px;
-      font-size: 22px;
-    }
-    ul.govuk-list {
-      font-size: 18px;
-      font-weight: bold;
-      color: $govuk-link-colour;
-    }
-    ul li {
-      margin-bottom: 30px;
-    }
-  }
-
-  .xpl-menu-search-input {
-    input {
-      height: 50px;
-      width: calc(100% - 50px);
-      font-size: 22px;
-    }
-    label {
-      font-size: 22px;
-      margin-bottom: 30px;
-    }
-    button {
-      vertical-align: top;
-      display: inline-block;
-      width: 50px;
-      height: 50px;
-      cursor: pointer;
-      background-image: url("/public/images/magnifying-glass.png");
-      background-repeat: no-repeat;
-      background-position: 6px 6px;
-      background-size: 35px;
-      background-color: black;
-      text-indent: -5000px;
-      overflow: hidden;
-    }
-    .govuk-form-group {
-      margin-bottom: 40px;
-    }
-    .govuk-heading-l {
-      margin-bottom: 30px;
-    }
-  }
-
-  .xpl-accordion {
-    margin-bottom: 0;
-    border-bottom: 0;
-    &__controls {
-      display: none;
-    }
-    &__icon {
-      position: absolute;
-      top: 50%;
-      right: 15px;
-      width: 16px;
-      height: 16px;
-      margin-top: -8px;
-      background-image: url("/public/images/chevron-down.svg");
-    }
-    &__section:hover, &__section-link:hover {
-      background: #f3f2f1;
-    }
-    &__section--expanded {
-      background: #f3f2f1;
-      .xpl-accordion__icon {
-        background-image: url("/public/images/chevron-up.svg");
-      }
-      .xpl-accordion__section-content {
-        display: block;
-      }
-    }
-    &__section, &__section-link {
-      border-bottom: 1px solid $govuk-border-colour;
-    }
-    &__section-link {
-      h2 {
-        font-size: 22px;
-        font-weight: 700;
-        a:visited {
-          color: $govuk-link-colour;
-        }
-      }
-    }
-    &__section-heading {
-      margin: 0;
-      button {
-        color: $govuk-link-colour;
-      }
-    }
-    &__section-button {
-      margin-top: 0;
-      margin-bottom: 0;
-      margin-left: 0;
-      border-width: 0;
-      padding: 0;
-      background: none;
-      font-weight: bold;
-      font-size: 22px;
-      text-align: left;
-      cursor: pointer;
-      &:focus {
-        outline: 3px solid transparent;
-        color: #0b0c0c;
-        background-color: #ffdd00;
-        box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
-        text-decoration: none;
-      }
-    }
-    &__section-header {
-      position: relative;
-      margin-left: 25px;
-      margin-right: 25px;
-      padding-left: 0;
-      padding-right: 0;
-      padding-top: 30px;
-      padding-bottom: 30px;
-      border: 0;
-      cursor: pointer;
-      &:hover {
-        box-shadow: none;
-      }
-    }
-    &__section-content {
-      display: none;
-      margin-left: 30px;
-      margin-right: 30px;
-      padding-top: 0;
-      a:link, a:visited {
-        font-size: 18px;
-        font-weight: bold;
-        color: $govuk-link-colour;
-      }
-      a:focus {
-        color: govuk-colour("black");
-      }
-      p {
-        padding-top: 3px;
-        margin-bottom: 0;
-      }
-      ul li {
-        padding-bottom: 30px;
-      }
-    }
-  }
-
-  // New link styles for menu in mobile view
-  .govuk-header__menu-button:hover {
-    text-decoration-thickness: $govuk-heavy-link-underline-thickness;
-  }
-
-  .xpl-accordion__section-heading {
-    button {
-      border-bottom: $govuk-link-underline-thickness solid;
-
-      &:hover {
-        margin-bottom: $govuk-heavy-link-underline-thickness * -0.5;
-        border-bottom: $govuk-heavy-link-underline-thickness solid;
-      }
-
-      &:focus {
-        margin-bottom: 0;
-        border-bottom: 0;
-      }
-    }
-
-    a {
-      text-decoration: underline;
-      text-decoration-thickness: $govuk-link-underline-thickness;
-
-      &:hover {
-        text-decoration-thickness: 3px;
-      }
-    }
-  }
-
-  .xpl-accordion__section-content {
-    a {
-      text-decoration: underline;
-      text-decoration-thickness: $govuk-link-underline-thickness;
-
-      &:hover {
-        text-decoration-thickness: 3px;
-      }
-    }
-  }
-
-
-  #xpl-popup-menu {
-    #navigation {
-      height: 100vh;
-      .xpl-below-accordion li.govuk-header__navigation-item.xpl-minor-nav-item {
-        margin-left: 5px;
-        margin-right: 5px;
-        padding: 15px 0 0 0;
-        a {
-          font-weight: normal;
-          font-size: 18px;
-        }
-      }
-    }
-  }
-
-  .govuk-header__menu-button {
-    font-family: $font;
-    top: 0;
-    border-left: 1px solid #666;
-    padding: 20px 20px 16px 0;
-    font-size: 18px;
-    line-height: 12px;
-    font-weight: bold;
-    &:focus {
-      box-shadow: none;
-    }
-    &.govuk-js-header-toggle {
-      width: 100px;
-      height: 55px;
-      &.govuk-header__menu-button--open {
-        background: govuk-colour("white");
-        border: none;
-        color: govuk-colour("black");
-        padding-right: 0;
-        font-size: 34px;
-        font-weight: 100;
-        &::after {
-          display: none;
-        }
-      }
-    }
-
-    &#xpl-menu-button {
-      right: 60px;
-      &::after {
-        content: "";
-        display: block;
-        position: absolute;
-        top: 24px;
-        bottom: 0;
-        right: 18px;
-        width: 7px;
-        height: 7px;
-        -webkit-transform: rotate(137deg);
-        -ms-transform: rotate(137deg);
-        transform: rotate(137deg);
-        border: solid;
-        border-width: 2px 2px 0 0;
-        border-color: white;
-        clip-path: none;
-        -webkit-clip-path: none;
-      }
-    }
-
-    &#xpl-search-button {
-      right: 0;
-      width: 60px;
-      cursor: pointer;
-      background-image: url("/public/images/magnifying-glass.png");
-      background-repeat: no-repeat;
-      background-position: 11px 11px;
-      background-size: 35px auto;
-      text-indent: -5000px;
-      overflow: hidden;
-      &::after {
-        display: none;
-      }
-      &.govuk-header__menu-button--open {
-        background: white;
-        text-indent: 0;
-      }
-    }
-  }
-
-  .govuk-header__navigation-item {
-    border: none;
-    padding: 0 0 30px 0;
-    color: govuk-colour("black");
-    a:link, a:visited {
-      font-size: 18px;
-      color: govuk-colour("white");
-    }
-    button.xpl-search-button:focus {
-      outline: 3px solid #fd0;
-      outline-offset: 0;
-      box-shadow: inset 0 0 0 4px #0b0c0c;
-    }
-    .govuk-list &-2 {
-      padding-bottom: 28px;
-      a:link, a:visited {
-        color: govuk-colour("blue");
-        font-size: 18px;
-      }
-    }
-    &.xpl-minor-nav-item {
-      margin-left: -25px;
-      margin-right: -25px;
-      padding-bottom: 0;
-      &:last-of-type {
-        padding-bottom: 60px;
-      }
-      a {
-        margin-left: 25px;
-        margin-right: 25px;
-      }
-    }
-    h2 {
-      margin: 30px 0 30px 0;
-      font-size: 22px;
-      font-weight: bold;
-    }
-    hr {
-      margin-left: -25px;
-      margin-right: -25px;
-      border-color: govuk-colour("black");
-      border-width: 1px 0 0 0;
-    }
-  }
-  .govuk-header__container {
-    margin-bottom: 0;
-    border-bottom: none;
-    min-height: 40px;
-    z-index: 3;
-  }
-  nav {
-    background: govuk-colour("white");
-    margin-left: -25px;
-    margin-right: -25px;
-    padding-left: 25px;
-    padding-right: 25px;
-
-    .govuk-js-header-toggle .arrow {
-      vertical-align: 4px;
-      font-weight: bold;
-      padding-left: 3px;
-    }
-
-    .govuk-js-search-toggle {
-      background-image: url("/assets/frontend/govuk_publishing_components/search-button-ca89b2a79f944909ceb7370d3f0b78811d32b96e883348fcd8886f63dd619585.png");
-      background-position: 105% 50%;
-      background-size: 70px auto;
-      text-indent: -5000px;
-      right: -20px;
-      width: 50px;
-      height: 50px;
-      &.govuk-js-search-toggle--open {
-        background-color: govuk-colour("white");
-        color: govuk-colour("black");
-        text-indent: 0;
-      }
-    }
-  }
-
-  .xpl-menu__button {
-    font-family: $font;
-    background: none;
-    border: 0;
-    padding: 0;
-    font-size: 22px;
-    font-weight: bold;
-    color: $govuk-link-colour;
-    display: block;
-  }
-
-
-  .govuk-header__navigation, #xpl-search-box {
-    padding-top: 20px;
-    margin: 0 auto 0 auto;
-    max-width: 960px;
-  }
-
-  #xpl-search-box {
-    padding: 30px 0 60px 0;
-    h2 {
-      color: govuk-colour("black");
-      margin: 0;
-      margin-bottom: 30px;
-    }
-    button {
-      background-color: govuk-colour("blue");
-    }
-  }
-}
-
-// Very small width
-@include govuk-media-query ($until: $mobile-width) {
-  .explore-header {
-    svg {
-      width: 25px;
-      padding-top: 3px;
-    }
-    .govuk-header__logo {
-      padding: 0;
-      min-height: 39px;
-    }
-    .govuk-header__logotype-text {
-      font-size: 20px;
-    }
-    .govuk-header__container {
-      padding-left: 25px;
-      padding-top: 5px;
-    }
-    .govuk-header__menu-button {
-      top: -1px;
-      padding-left: 5px;
-      padding-right: 5px;
-      padding-top: 0;
-      padding-bottom: 0;
-    }
-    .govuk-header__menu-button#xpl-menu-button {
-      right: 45px;
-      width: 82px;
-      height: 45px;
-      padding-left: 12px;
-      font-size: 16px;
-      text-align: left;
-      &::after {
-        top: 20px;
-        right: 11px;
-        width: 5px;
-        height: 5px;
-      }
-    }
-    .govuk-header__menu-button--open#xpl-menu-button {
-      text-align: center;
-      font-size: 34px;
-      padding-left: 0;
-    }
-    .govuk-header__menu-button#xpl-search-button {
-      width: 45px;
-      height: 45px;
-      background-size: 25px auto;
-      background-position: 10px 10px;
-    }
-    .xpl-accordion__section-heading {
-      margin-right: 20px;
-    }
-  }
-}
-
-.explore-header .xpl-accordion__section-heading .xpl-accordion__section-button:focus {
-  margin-bottom: govuk-em(1px, 22px);
-}
-
-
-// Desktop
-
-@include govuk-media-query ($from: $desktop-width) {
-  .explore-header {
-    .govuk-header__container {
-      padding: 0 25px 0 25px;
-      margin-left: auto;
-      margin-right: auto;
-      max-width: 960px;
-      &--old-page {
-        padding: 0 30px 0 30px;
-      }
-    }
-
-    .govuk-header__logo {
-      width: 180px;
-      margin-top: 10px;
-    }
-    .govuk-header__content {
-      float: right;
-      width: 74.55%;
-    }
-    .xpl-nav--desktop {
-      display: block;
+    &:after {
       background: govuk-colour("black");
-      border: none;
-      button {
-        color: govuk-colour("white");
-        font-size: 16px;
-      }
-      .govuk-header__navigation {
-        min-height: unset;
-        position: absolute;
-        right: 25px;
-        padding-top: 0;
-      }
-      .govuk-header__navigation-item {
-        padding: 20px 30px 0 20px;
-        margin-right: 0;
-        cursor: pointer;
-        a:link, a:visited {
-          color: govuk-colour("white");
-          font-size: 16px;
-        }
-        &--active {
-          a:link, a:visited {
-            color: $govuk-link-colour;
-          }
-        }
-        &#xpl-topics-menu-item, &#xpl-activity-menu-item {
-          button {
-            font-family: $font;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-            font-weight: 700;
-            font-size: 16px;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            &:focus {
-              outline: 3px solid transparent;
-              color: #0b0c0c;
-              background-color: #ffdd00;
-              box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
-              text-decoration: none;
-            }
-            &:after {
-              content: "";
-              display: block;
-              position: absolute;
-              top: 5px;
-              right: -24px;
-              width: 6px;
-              height: 6px;
-              -webkit-transform: rotate(137deg);
-              -ms-transform: rotate(137deg);
-              transform: rotate(137deg);
-              border: solid;
-              border-width: 2px 2px 0 0;
-              border-color: white;
-              clip-path: none;
-            }
-          }
-          &.menu-item-open {
-            button:after {
-              -webkit-transform: rotate(317deg);
-              -ms-transform: rotate(317deg);
-              transform: rotate(317deg);
-              border: solid;
-              border-width: 2px 2px 0 0;
-              border-color: black;
-              clip-path: none;
-              top: 7px;
-              cursor: pointer;
-            }
-          }
-        }
-        &#xpl-search-menu-item {
-          padding: 0;
-          vertical-align: top;
-          &.menu-item-open {
-            button {
-              height: 55px;
-              background: white;
-              background-image: url("/public/images/black-cross.png");
-              background-size: 15px auto;
-              background-repeat: no-repeat;
-              background-position: 50% 50%;
-            }
-          }
-          button, a {
-            display: block;
-            position: static;
-            right: 0;
-            width: 54px;
-            height: 54px;
-            cursor: pointer;
-            background-image: url("/public/images/magnifying-glass.png");
-            background-repeat: no-repeat;
-            background-position: 10px 11.2px;
-            background-size: 35px;
-            background-color: #1d70b8;
-            text-indent: -5000px;
-            overflow: hidden;
-          }
-        }
-      }
-
-      .xpl-frame2 {
-        position: absolute;
-        left: 50%;
-        right: 50%;
-        margin-left: -50vw;
-        margin-right: -50vw;
-        top: 55px;
-        z-index: 15;
-        width: 100vw;
-        background: govuk-colour("white");
-
-        &-inner {
-          max-width: 960px;
-          margin: 40px auto 60px auto;
-          padding-left: 20px;
-          padding-right: 20px;
-
-          h2 {
-            font-size: 22px;
-          }
-
-          h2:first-of-type {
-            padding-top: 0;
-          }
-
-          li a {
-            text-decoration: underline;
-
-            &:link {
-              font-weight: bold;
-            }
-
-            &:hover,
-            &:focus {
-              margin-bottom: 5px;
-              text-decoration-thickness: 3px;
-              text-underline-offset: 0.15em;
-            }
-
-            &:focus {
-              border-bottom: 0;
-            }
-          }
-
-          .xpl-minor-item {
-            border-top: 1px solid $govuk-border-colour;
-            padding-top: 30px;
-          }
-          ul {
-            padding: 0;
-            margin: 0;
-            vertical-align: top;
-            li {
-              margin-bottom: 30px;
-              display: block;
-            }
-            li div, li p {
-              color: govuk-colour("black");
-              font-size: 16px;
-              padding: 0;
-            }
-          }
-          .xpl-dropdown-intro {
-            color: black;
-            font-size: 22px;
-            vertical-align: top;
-          }
-        }
-        &#xpl-frame2-search {
-          a:link, a:visited {
-            font-size: 19px;
-          }
-          h2.govuk-heading-l {
-            padding-bottom: 30px;
-            margin-bottom: 0;
-          }
-          button.govuk-input__suffix:focus {
-            outline: 3px solid #fd0;
-            outline-offset: 0;
-            box-shadow: inset 0 0 0 4px #0b0c0c;
-          }
-        }
-      }
-    }
-    .xpl-backdrop {
-      position: absolute;
-      left: 50%;
-      right: 50%;
-      margin-left: -50vw;
-      margin-right: -50vw;
-      top: 58px;
-      width: 100vw;
-      height: 200vh;
-      background: black;
-      opacity: 0.8;
-    }
-    .xpl-nav {
-      display: none;
-    }
-    .govuk-header__navigation--open::after {
-      display: none;
-    }
-
-    $govuk-heavy-link-underline-thickness: 3px !default;
-    .govuk-header__navigation-item {
-      a {
-        &:link,
-        &:visited {
-          text-decoration: none;
-        }
-
-        &:hover {
-          text-decoration: underline;
-          text-decoration-thickness: 3px;
-        }
-      }
-      &:hover {
-        button {
-          text-decoration: none;
-          margin-bottom: $govuk-heavy-link-underline-thickness *-1;
-          border-bottom: 3px solid;
-        }
-      }
-      &.menu-item-open {
-        background-color: govuk-colour("white");
-        padding-bottom: 20px;
-        color: $menu-hover-colour;
-        &:hover {
-          button {
-            text-decoration: none;
-          }
-          button:after {
-            border-color: black;
-          }
-        }
-        button {
-          cursor: pointer;
-          color: govuk-colour("black");
-        }
-      }
-    }
-  }
-}
-
-
-// JS-specific styling
-
-.js-enabled .explore-header {
-  nav {
-    padding-left: 20px;
-    padding-right: 20px;
-    &.xpl-nav--desktop {
-      border: none;
-    }
-  }
-  .xpl-nav--desktop {
-    border: none;
-
-    .xpl-frame2 a:focus {
-      margin-bottom: govuk-em(6px, 18px);
-    }
-  }
-
-  // Add extra line spacing - using padding because of the accordion markup
-  .xpl-accordion__section-content p {
-    padding-top: 5px;
-  }
-
-  .xpl-nav--desktop .xpl-frame2 a:focus {
-    margin-bottom: 5px;
-  }
-}
-
-@include govuk-media-query ($from: $desktop-width) {
-  .js-enabled .explore-header {
-    .govuk-header__container {
-      .govuk-header__navigation-item {
-        a:link, a:visited, button#xpl-activity-button-desktop, button#xpl-topics-button-desktop {
-          font-size: 16px;
-        }
-        a:focus {
-          color: govuk-colour("black");
-        }
-      }
-    }
-    .xpl-accordion__section-heading button:focus {
-      margin-bottom: govuk-em(1px, 22px);
-    }
-    .xpl-nav {
-      .govuk-header__navigation-item {
-        padding: 15px 0 15px 0;
-      }
-    }
-    .xpl-nav--desktop {
+      bottom: 0;
+      content: " ";
       display: block;
-      .govuk-header__navigation {
-        padding-top: 0;
-        margin: unset auto;
-      }
-      .govuk-header__navigation-item {
-        &#xpl-topics-menu-item {
-          padding-right: 55px;
-        }
-        &#xpl-activity-menu-item {
-          padding-right: 45px;
-        }
-      }
-      .xpl-frame2 {
-        a {
-          &:link {
-            color: $govuk-link-colour;
-          }
+      height: govuk-spacing(1);
+      left: govuk-spacing(4);
+      position: absolute;
+      right: govuk-spacing(4);
+    }
 
-          &:focus {
-            color: #0b0c0c;
-          }
+    &:hover {
+      background: govuk-colour("black");
+      color: govuk-colour("mid-grey");
+
+      &:after {
+        background-color: govuk-colour("mid-grey");
+      }
+    }
+
+    &:focus {
+      @include govuk-focused-text;
+      box-shadow: none;
+
+      &:after {
+        background-color: $govuk-focus-text-colour;
+      }
+    }
+
+    &,
+    &:visited {
+      color: govuk-colour("white");
+    }
+  }
+}
+
+%toggle-base {
+  @extend %top-level-navigation-link-base;
+  @include govuk-font($size: 16, $weight: false, $line-height: 20px);
+  border-radius: 0;
+  cursor: pointer;
+  padding: govuk-spacing(4);
+  right: 0;
+  top: 0;
+
+  @include govuk-media-query($from: desktop) {
+    border: none;
+  }
+}
+
+%top-level-navigation-toggle-base {
+  @extend %toggle-base;
+  border-top: 1px solid govuk-colour("black");
+  height: govuk-spacing(9);
+
+  &:focus {
+    border-color: $govuk-focus-colour;
+  }
+
+  &.gem-c-layout-super-navigation-header__open-button {
+    border-left-color: govuk-colour("black");
+    border-right-color: govuk-colour("black");
+
+    &,
+    &:hover {
+      background: govuk-colour("light-grey");
+      color: govuk-colour("light-grey");
+    }
+
+    &:focus {
+      color: $govuk-focus-colour;
+      background: $govuk-focus-colour;
+    }
+
+    &:before,
+    &:after {
+      $width: govuk-spacing(4);
+      $height: 4px;
+
+      border: none;
+      content: " ";
+      display: block;
+      margin: 0;
+      width: $width;
+      height: $height;
+      background: govuk-colour("black");
+      transform-origin: center;
+      position: absolute;
+      top: calc(50% - #{$height / 2});
+      left: calc(50% - #{$width / 2});
+    }
+
+    &:before {
+      transform: rotate(45deg);
+    }
+
+    &:after {
+      transform: rotate(-45deg);
+    }
+  }
+}
+
+%search-icon {
+  height: $search-icon-size;
+  pointer-events: none;
+  width: $search-icon-size;
+  color: govuk-colour("white");
+}
+
+// Header layout - black bar and logo.
+.gem-c-layout-super-navigation-header {
+  background: govuk-colour("black");
+  position: relative;
+
+  .lte-ie8 & {
+    height: govuk-spacing(9);
+  }
+
+  [hidden] {
+    display: none;
+  }
+}
+
+.gem-c-layout-super-navigation-header__container {
+  position: relative;
+
+  @include govuk-media-query($from: desktop) {
+    position: static;
+  }
+}
+
+.gem-c-layout-super-navigation-header__header-logo {
+  height: govuk-spacing(6);
+  padding-top: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: desktop) {
+    display: block;
+    float: left;
+  }
+}
+
+.gem-c-layout-super-navigation-header__content {
+  @include govuk-media-query($from: desktop) {
+    display: block;
+    float: right;
+  }
+}
+
+// Top level navigation and search.
+.gem-c-layout-super-navigation-header__navigation-items,
+.gem-c-layout-super-navigation-header__search-items {
+  background: govuk-colour("light-grey");
+  display: block;
+  list-style: none;
+  margin: 0 (0 - govuk-spacing(3));
+  padding: 0;
+
+  @include govuk-media-query($from: tablet) {
+    margin: 0 (0 - govuk-spacing(6));
+  }
+
+  @include govuk-media-query($from: desktop) {
+    background: none;
+    float: left;
+    padding: 0;
+    margin: 0;
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-items {
+  .js-enabled & {
+    padding: 0 0 govuk-spacing(9) 0;
+
+    @include govuk-media-query($from: desktop) {
+      padding: 0;
+    }
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-item,
+.gem-c-layout-super-navigation-header__search-item {
+  margin-right: 0;
+  padding: 0;
+
+  @include govuk-media-query($from: desktop) {
+    border-bottom: none;
+    float: left;
+    padding: 0;
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-item {
+  &:after {
+    background-color: $govuk-border-colour;
+    content: " ";
+    display: block;
+    height: 1px;
+    left: 0;
+    right: 0;
+    position: absolute;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    &:after {
+      content: none;
+    }
+  }
+}
+
+// Top level navigation links.
+.gem-c-layout-super-navigation-header__navigation-item-link {
+  @extend %top-level-navigation-link-base;
+
+  &,
+  &:link, // 👈 required to override govuk-template
+  &:visited {
+    color: $govuk-link-colour;
+
+    &:hover {
+      color: $govuk-link-hover-colour;
+
+      @include govuk-media-query($from: desktop) {
+        color: govuk-colour("mid-grey");
+      }
+    }
+
+    &:focus {
+      color: $govuk-focus-text-colour;
+    }
+
+    @include govuk-media-query($from: desktop) {
+      color: govuk-colour("white");
+    }
+  }
+
+  // This :link:focus selector is required to override the `govuk-template`
+  // defaults.
+  &:link:focus {
+    color: $govuk-focus-text-colour;
+  }
+
+  .js-enabled & {
+    @include govuk-media-query($until: "desktop") {
+      padding: govuk-spacing(6) govuk-spacing(3) govuk-spacing(6) govuk-spacing(9);
+    }
+
+    @include govuk-media-query($until: "tablet") {
+      padding-left: govuk-spacing(7);
+    }
+  }
+}
+
+// Search link and dropdown.
+.gem-c-layout-super-navigation-header__search-item-link {
+  @extend %top-level-navigation-link-base;
+
+  @include govuk-media-query($from: desktop) {
+    background: $govuk-link-colour;
+    margin-left: 0;
+
+    &:focus:hover:after,
+    &:after {
+      content: none;
+    }
+
+    &:hover:after {
+      content: " ";
+      left: 0;
+      right: 0;
+    }
+  }
+}
+
+.gem-c-layout-super-navigation-header__search-item-link-text {
+  @include govuk-media-query($from: desktop) {
+    @include govuk-visually-hidden;
+  }
+}
+
+.gem-c-layout-super-navigation-header__search-item-link-icon {
+  @extend %search-icon;
+  display: none;
+
+  @include govuk-media-query($from: desktop) {
+    display: block;
+  }
+}
+
+.gem-c-layout-super-navigation-header__search-toggle-button-link-icon {
+  @extend %search-icon;
+  display: block;
+}
+
+// Search and popular content dropdown.
+.gem-c-layout-super-navigation-header__search-and-popular {
+  display: none;
+  padding-bottom: govuk-spacing(4);
+  padding-top: govuk-spacing(4);
+
+  .js-enabled & {
+    display: block;
+  }
+}
+
+// Styles for top level navigation toggle button.
+.gem-c-layout-super-navigation-header__navigation-top-toggle-button {
+  @extend %top-level-navigation-toggle-base;
+  border-left: 1px solid govuk-colour("mid-grey");
+  color: govuk-colour("white");
+  position: absolute;
+  right: 45px;
+
+  &.gem-c-layout-super-navigation-header__open-button {
+    border-top-color: govuk-colour("black");
+  }
+
+  @include govuk-media-query($from: 360px) {
+    &:before {
+      @include chevron("white");
+    }
+  }
+
+  &:focus {
+    &:before {
+      border-color: $govuk-focus-text-colour;
+    }
+  }
+
+  @include govuk-media-query(360px) {
+    right: 60px;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}
+
+// styles for search toggle button
+.gem-c-layout-super-navigation-header__search-toggle-button {
+  @extend %top-level-navigation-toggle-base;
+  border-top: 1px solid transparent;
+  border-left: 1px solid govuk-colour("mid-grey");
+  color: govuk-colour("white");
+  position: absolute;
+  right: (0 - govuk-spacing(3));
+
+  &:after {
+    background-color: $govuk-link-colour;
+    content: " ";
+    left: 0;
+    right: 0;
+  }
+
+  &:not(.gem-c-layout-super-navigation-header__open-button):focus {
+    &:hover,
+    &:after {
+      background-color: $govuk-focus-colour;
+      border-top-color: $govuk-focus-colour;
+    }
+  }
+
+  @include govuk-media-query($from: 360px) {
+    right: 0;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    background-color: $govuk-link-colour;
+    border-left: 0;
+    height: govuk-spacing(9);
+    margin-left: govuk-spacing(3);
+    padding: govuk-spacing(4);
+    position: relative;
+    float: right;
+
+    &.gem-c-layout-super-navigation-header__open-button {
+      border-top-color: govuk-colour("black");
+
+      &:hover:after {
+        content: " ";
+      }
+    }
+
+    // To avoid the 'sticky hover' problem, we need to stop the hover state on
+    // touch screen devices.
+    //
+    // One solution is to use `@media(hover: hover)`. This turns on the hover
+    // state only for devices that aren't touchscreen, but means that browsers
+    // that don't support this media query won't get a hover state at all.
+    //
+    // To get around this, we do the opposite - we turn off the hover state for
+    // for touchscreen devices.
+    @media (hover: none), (pointer: coarse) {
+      &:not(:focus):hover {
+        background-color: $govuk-link-colour;
+        color: govuk-colour("white");
+
+        &:after {
+          background-color: $govuk-link-colour;
         }
       }
     }
+  }
+}
+
+// styles for second level navigation toggle buttons
+.gem-c-layout-super-navigation-header__navigation-second-toggle-button {
+  @extend %toggle-base;
+  @include govuk-font($size: 24, $weight: false, $line-height: 20px);
+  border: 0;
+  margin: 0;
+  padding: govuk-spacing(6) govuk-spacing(3);
+  position: relative;
+  text-align: left;
+  text-decoration: none;
+  width: 100%;
+
+  &:before {
+    @include chevron("black");
+  }
+
+  &,
+  &:visited {
+    color: $govuk-link-colour;// FIXME: contrast against govuk-colour("light-grey") not high enough
+
+    @include govuk-media-query($from: desktop) {
+      color: govuk-colour("white");
+    }
+  }
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(6);
+  }
+
+  @include govuk-media-query($from: desktop) {
+    @include govuk-font($size: 16, $weight: false, $line-height: 20px);
+    border-top: 1px solid transparent;
+    color: govuk-colour("white");
+    height: govuk-spacing(9);
+    padding: govuk-spacing(4);
+    position: relative;
+
+    &:before {
+      border-color: govuk-colour("white");
+    }
+
+    &:hover {
+      color: govuk-colour("mid-grey");
+
+      &:after {
+        background-color: govuk-colour("mid-grey");
+      }
+
+      &:before {
+        border-color: govuk-colour("mid-grey");
+      }
+    }
+
+    &:focus {
+      color: $govuk-focus-text-colour;
+
+      &:after {
+        background-color: $govuk-focus-text-colour;
+      }
+
+      &:before {
+        border-color: $govuk-focus-text-colour;
+      }
+    }
+  }
+
+  &.gem-c-layout-super-navigation-header__open-button {
+    border-top-color: govuk-colour("black");
+
+    &:before {
+      transform: translateY(20%) rotate(225deg);
+    }
+
+    @include govuk-media-query($from: desktop) {
+      background-color: govuk-colour("light-grey");
+      color: $govuk-link-colour;
+
+      &:after {
+        background: $govuk-link-colour;
+      }
+
+      &:before {
+        border-color: $govuk-link-colour;
+      }
+
+      &:focus {
+        background-color: $govuk-focus-colour;
+        color: $govuk-focus-text-colour;
+
+        &:after {
+          background-color: $govuk-focus-text-colour;
+        }
+
+        &:before {
+          border-color: $govuk-focus-text-colour;
+        }
+      }
+
+      &:active {
+        background-color: govuk-colour("light-grey");
+        color: $govuk-link-colour;
+
+        &:before {
+          border-color: $govuk-link-colour;
+        }
+      }
+    }
+  }
+}
+
+// Dropdown menu.
+.gem-c-layout-super-navigation-header__navigation-dropdown-menu {
+  background: govuk-colour("white");
+
+  @include govuk-media-query($from: desktop) {
+    background: govuk-colour("light-grey");
+    left: 0;
+    position: absolute;
+    right: 0;
+  }
+}
+
+// Dropdown menu description.
+.gem-c-layout-super-navigation-header__menu-description {
+  display: none;
+
+  @include govuk-media-query($from: desktop) {
+    display: block;
+    padding: govuk-spacing(7) 0 govuk-spacing(7) 0;
+  }
+}
+
+// Dropdown menu items.
+.gem-c-layout-super-navigation-header__dropdown-list-item {
+  @include govuk-media-query($from: desktop) {
+    padding: govuk-spacing(2) 0;
+  }
+}
+
+// Navigation menu items.
+.gem-c-layout-super-navigation-header__navigation-second-items {
+  margin: 0 auto;
+  padding: govuk-spacing(2) 0 govuk-spacing(6) 0;
+
+  @include govuk-media-query($from: desktop) {
+    margin-left: (0 - govuk-spacing(3));
+    margin-right: (0 - govuk-spacing(3));
+    padding: govuk-spacing(6) 0 govuk-spacing(8) 0;
+
+    & > li {
+      box-sizing: border-box;
+      margin-bottom: 0;
+      padding-left: govuk-spacing(3);
+      padding-right: govuk-spacing(3);
+    }
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-second-items--topics {
+  @include govuk-media-query($from: desktop) {
+    @include columns(18, 2, "li");
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-second-items--government-activity {
+  @include govuk-media-query($from: desktop) {
+    @include columns(5, 2, "li");
+    padding-bottom: govuk-spacing(3);
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-second-item-link {
+  display: inline-block;
+  padding: govuk-spacing(2) 0;
+
+  @include govuk-media-query($from: desktop) {
+    display: inline;
+    font-weight: bold;
+    padding: 0;
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-second-item-link--with-description {
+  @include govuk-font($size: 19, $weight: bold);
+  margin-top: govuk-spacing(2);
+  margin-bottom: 0;
+}
+
+// Dropdown menu footer links.
+.gem-c-layout-super-navigation-header__navigation-second-footer {
+  border-top: 1px solid govuk-colour("mid-grey");
+}
+
+.gem-c-layout-super-navigation-header__navigation-second-footer-list {
+  list-style: none;
+  padding-bottom: govuk-spacing(8);
+  padding-top: govuk-spacing(4);
+
+  @include govuk-grid-column($width: "two-thirds", $float: right, $at: "desktop");
+
+  @include govuk-media-query($from: desktop) {
+    padding: govuk-spacing(7) 0 govuk-spacing(8) 0;
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-second-footer-item {
+  @include govuk-media-query($from: desktop) {
+    box-sizing: border-box;
+    float: left;
+    width: 50%;
+    padding: 0 govuk-spacing(3);
+  }
+}
+
+.gem-c-layout-super-navigation-header__navigation-second-footer-link {
+  @include govuk-font($size: 19, $weight: bold);
+  display: inline-block;
+  margin: govuk-spacing(1) 0;
+  padding: govuk-spacing(2) 0;
+
+  @include govuk-media-query($from: desktop) {
+    display: inline;
+    font-weight: bold;
+    padding: 0;
+  }
+}
+
+// Search dropdown.
+.gem-c-layout-super-navigation-header__search-items {
+  background: govuk-colour("light-grey");
+  margin: 0 (0 - govuk-spacing(3));
+
+  @include govuk-media-query($from: tablet) {
+    margin: 0 (0 - govuk-spacing(6));
+  }
+
+  @include govuk-media-query($from: desktop) {
+    margin: 0;
+
+    .js-enabled & {
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 60px;
+    }
+  }
+}
+
+.gem-c-layout-super-navigation-header__search-form {
+  padding: govuk-spacing(3) 0 govuk-spacing(6) 0;
+}
+
+// Popular links.
+.gem-c-layout-super-navigation-header__popular-link {
+  padding: govuk-spacing(2) 0;
+  display: inline-block;
+
+  @include govuk-media-query($from: desktop) {
+    margin: govuk-spacing(1) 0;
+    padding: 0;
   }
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -139,13 +139,6 @@ router.get('/', function (req, res) {
 // If content is an "end of journey" content type, return the generic content template
 // Otherwise, modify the body of all pages returned from gov.uk to add the Explore elements
 const augmentedBody = function (req, response, body) {
-  const headerTemplate = fs.readFileSync('app/views/explore-header.html', 'utf8')
-  const headerString = nunjucks.renderString(headerTemplate, {req})
-  const headerStringWithCss = `
-  <link href="/public/stylesheets/explore-header.css" media="all" rel="stylesheet" type="text/css" />
-  <link href="/public/stylesheets/explore-govuk-overrides.css" media="all" rel="stylesheet" type="text/css" />
-  ` + headerString
-
   const footerTemplate = fs.readFileSync('app/views/explore-footer.html', 'utf8')
 
   // Make all src and ref attributes absolute, or the server will try to
@@ -153,12 +146,10 @@ const augmentedBody = function (req, response, body) {
   return body
     .replace(/(href|src)="\//g, '$1="https://www.gov.uk/')
     .replace(/<body( class=")*?/, '<body class="explore-body"')
-    .replace(/<header[^]+?<\/header>/, headerStringWithCss)
     .replace(/<footer[^]+?<\/footer>/, footerTemplate)
     .replace(
       '<div class="govuk-header__container govuk-width-container">',
       '<div class="govuk-header__container govuk-header__container--old-page govuk-width-container">')
-    .replace(/<\/body>/,'<script src="/public/javascripts/explore-header.js"></script>\n</body>')
     .replace(/<a(.*) href\s*=\s*(['"])\s*(https:)?\/\/www.gov.uk\//g,'<a $1 href=$2/')
 }
 

--- a/app/views/explore-header.html
+++ b/app/views/explore-header.html
@@ -1,11 +1,13 @@
-<header class="govuk-header explore-header" role="banner" data-module="govuk-header">
-  <div class="govuk-header__container govuk-width-container">
-    <div class="govuk-header__logo">
-      <a href="/" class="govuk-header__link govuk-header__link--homepage xpl-logo">
+<header role="banner" class="gem-c-layout-super-navigation-header">
+  <div class="gem-c-layout-super-navigation-header__container govuk-width-container govuk-clearfix">
+    <div class="gem-c-layout-super-navigation-header__header-logo">
+      <a class="govuk-header__link govuk-header__link--homepage" data-track-action="logoLink" data-track-category="headerClicked" data-track-label="https://www.gov.uk" data-track-dimension="GOV.UK" data-track-dimension-index="29" href="/" id="logo" title="Go to the GOV.UK homepage">
         <span class="govuk-header__logotype">
-          <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
-            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-            <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+          <svg aria-hidden="true" class="govuk-header__logotype-crown gem-c-layout-super-navigation-header__logotype-crown" focusable="false" height="30" viewBox="0 0 132 97" xmlns="http://www.w3.org/2000/svg" width="36">
+            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z">
+            </path>
+            <image class="govuk-header__logotype-crown-fallback-image" height="30" src="https://www.gov.uk/assets/static/govuk-logotype-crown-0cdbde943be3a6518a5d7c00b607d134f4d5e3d0e8c68a1bfa2dc81f1f3edc4e.png" width="36" xlink:href="">
+            </image>
           </svg>
           <span class="govuk-header__logotype-text">
             GOV.UK
@@ -13,258 +15,246 @@
         </span>
       </a>
     </div>
-
-    <div class="govuk-header__content">
-      <div class="xpl-backdrop" style="display: none"></div>
-
-      <!-- Desktop menu -->
-
-      <nav class="xpl-nav--desktop">
-        <ul id="navigation-desktop" class="govuk-header__navigation" aria-label="Navigation menu" aria-hidden="false">
-          <li id="xpl-topics-menu-item" class="govuk-header__navigation-item">
-            <a href="/topic" id="xpl-topics-button-desktop">Topics</a>
-
-          </li>
-          <li class="govuk-header__navigation-item {% if req.url === '/government/organisations' %}govuk-header__navigation-item--active{% endif %}">
-            <a href="/government/organisations">Departments</a>
-          </li>
-          <li id="xpl-activity-menu-item" class="govuk-header__navigation-item">
-            <a id="xpl-activity-button-desktop" href="/#activity">
-              Government activity
-            </a>
-          </li>
-          <li id="xpl-search-menu-item" class="govuk-header__navigation-item">
-            <a id="xpl-search-button-desktop" href="/search" class="xpl-search-button">
-              Search
-            </a>
-          </li>
-        </ul>
-
-        <div class="xpl-frame2" id="xpl-frame2-topics" style="display: none">
-          <div class="xpl-frame2-inner">
-            <div class="govuk-grid-row">
-              <div class="govuk-grid-column-one-third">
-                <p class="xpl-dropdown-intro">Find help, guidance and services</p>
+    <nav aria-labelledby="super-navigation-menu-heading" class="gem-c-layout-super-navigation-header__content" data-module="govuk-header">
+      <h2 id="super-navigation-menu-heading" class="govuk-visually-hidden">
+        Navigation menu
+      </h2>
+      <button aria-controls="super-navigation-menu" aria-expanded="true" aria-label="Hide navigation menu" class="gem-c-layout-super-navigation-header__navigation-top-toggle-button" data-text-for-hide="Hide navigation menu" data-text-for-show="Show navigation menu" data-toggle-desktop-group="hidden" data-toggle-mobile-group="top" data-tracking-key="menu" hidden="" id="super-navigation-menu-toggle" type="button">
+        Menu
+      </button>
+      <ul id="super-navigation-menu" class="gem-c-layout-super-navigation-header__navigation-items">
+          <li class="gem-c-layout-super-navigation-header__navigation-item gem-c-layout-super-navigation-header__navigation-item--with-children">
+            <a class="gem-c-layout-super-navigation-header__navigation-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse" data-track-dimension="Topics" data-track-dimension-index="29" href="/browse">Topics</a>
+              <button aria-controls="super-navigation-menu__section-98bf30f0" aria-expanded="false" aria-label="Show Topics menu" class="gem-c-layout-super-navigation-header__navigation-second-toggle-button" data-text-for-hide="Hide Topics menu" data-text-for-show="Show Topics menu" data-toggle-desktop-group="top" data-toggle-mobile-group="second" data-tracking-key="topics" hidden="" id="super-navigation-menu__section-98bf30f0-toggle" type="button">
+                Topics
+              </button>
+              <div hidden="" class="gem-c-layout-super-navigation-header__navigation-dropdown-menu" id="super-navigation-menu__section-98bf30f0">
+                <div class="govuk-width-container">
+                  <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-one-third-from-desktop">
+                        <p class="govuk-body-l gem-c-layout-super-navigation-header__menu-description">
+                          Find information and services
+                        </p>
+                    </div>
+                      <div class="govuk-grid-column-two-thirds-from-desktop">
+                          <ul class="govuk-list gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--topics">
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/benefits" data-track-dimension="Benefits" data-track-dimension-index="29" href="/browse/benefits">Benefits</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/births-deaths-marriages" data-track-dimension="Births, death, marriages and care" data-track-dimension-index="29" href="/browse/births-deaths-marriages">Births, death, marriages and care</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/brexit" data-track-dimension="Brexit" data-track-dimension-index="29" href="/brexit">Brexit</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/business" data-track-dimension="Business and self-employed" data-track-dimension-index="29" href="/browse/business">Business and self-employed</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/childcare-parenting" data-track-dimension="Childcare and parenting" data-track-dimension-index="29" href="/browse/childcare-parenting">Childcare and parenting</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/citizenship" data-track-dimension="Citizenship and living in the UK" data-track-dimension-index="29" href="/browse/citizenship">Citizenship and living in the UK</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/coronavirus" data-track-dimension="Coronavirus (COVID‑19)" data-track-dimension-index="29" href="/coronavirus">Coronavirus (COVID‑19)</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/justice" data-track-dimension="Crime, justice and the law" data-track-dimension-index="29" href="/browse/justice">Crime, justice and the law</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/disabilities" data-track-dimension="Disabled people" data-track-dimension-index="29" href="/browse/disabilities">Disabled people</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/driving" data-track-dimension="Driving and transport" data-track-dimension-index="29" href="/browse/driving">Driving and transport</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/education" data-track-dimension="Education and learning" data-track-dimension-index="29" href="/browse/education">Education and learning</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/employing-people" data-track-dimension="Employing people" data-track-dimension-index="29" href="/browse/employing-people">Employing people</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/environment-countryside" data-track-dimension="Environment and countryside" data-track-dimension-index="29" href="/browse/environment-countryside">Environment and countryside</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/housing-local-services" data-track-dimension="Housing and local services" data-track-dimension-index="29" href="/browse/housing-local-services">Housing and local services</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/tax" data-track-dimension="Money and tax" data-track-dimension-index="29" href="/browse/tax">Money and tax</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/abroad" data-track-dimension="Passports, travel and living abroad" data-track-dimension-index="29" href="/browse/abroad">Passports, travel and living abroad</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/visas-immigration" data-track-dimension="Visas and immigration" data-track-dimension-index="29" href="/browse/visas-immigration">Visas and immigration</a>
+                                
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link" data-module="gem-track-click" data-track-action="topicsLink" data-track-category="headerClicked" data-track-label="/browse/working" data-track-dimension="Working, jobs and pensions" data-track-dimension-index="29" href="/browse/working">Working, jobs and pensions</a>
+                                
+                              </li>
+                          </ul>
+                      </div>
+                  </div>
+                </div>
               </div>
-              <div class="govuk-grid-column-one-third">
-                <ul>
-                  <li><a href="/browse/benefits">Benefits</a></li>
-                  <li><a href="/browse/births-deaths-marriages">Births, death, marriages and care</a></li>
-                  <li><a href="/brexit">Brexit</a></li>
-                  <li><a href="/browse/business">Business and self-employed</a></li>
-                  <li><a href="/browse/childcare-parenting">Childcare and parenting</a></li>
-                  <li><a href="/browse/citizenship">Citizenship and living in the UK</a></li>
-                  <li><a href="/coronavirus">Coronavirus</a></li>
-                  <li><a href="/browse/justice">Crime, justice and the law</a></li>
-                  <li><a href="/browse/disabilities">Disabled people</a></li>
-                </ul>
+</li>          <li class="gem-c-layout-super-navigation-header__navigation-item">
+            <a class="gem-c-layout-super-navigation-header__navigation-item-link" data-module="gem-track-click" data-track-action="departmentsLink" data-track-category="headerClicked" data-track-label="/government/organisations" data-track-dimension="Departments" data-track-dimension-index="29" href="/government/organisations">Departments</a>
+</li>          <li class="gem-c-layout-super-navigation-header__navigation-item gem-c-layout-super-navigation-header__navigation-item--with-children">
+            <a class="gem-c-layout-super-navigation-header__navigation-item-link" data-module="gem-track-click" data-track-action="governmentactivityLink" data-track-category="headerClicked" data-track-label="/search/news-and-communications" data-track-dimension="Government activity" data-track-dimension-index="29" href="/search/news-and-communications">Government activity</a>
+              <button aria-controls="super-navigation-menu__section-c0b9442c" aria-expanded="false" aria-label="Show Government activity menu" class="gem-c-layout-super-navigation-header__navigation-second-toggle-button" data-text-for-hide="Hide Government activity menu" data-text-for-show="Show Government activity menu" data-toggle-desktop-group="top" data-toggle-mobile-group="second" data-tracking-key="governmentactivity" hidden="" id="super-navigation-menu__section-c0b9442c-toggle" type="button">
+                Government activity
+              </button>
+              <div hidden="" class="gem-c-layout-super-navigation-header__navigation-dropdown-menu" id="super-navigation-menu__section-c0b9442c">
+                <div class="govuk-width-container">
+                  <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-one-third-from-desktop">
+                        <p class="govuk-body-l gem-c-layout-super-navigation-header__menu-description">
+                          Find out what the government is doing
+                        </p>
+                    </div>
+                      <div class="govuk-grid-column-two-thirds-from-desktop">
+                          <ul class="govuk-list gem-c-layout-super-navigation-header__navigation-second-items gem-c-layout-super-navigation-header__navigation-second-items--government-activity">
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-module="gem-track-click" data-track-action="governmentactivityLink" data-track-category="headerClicked" data-track-label="/search/news-and-communications" data-track-dimension="News" data-track-dimension-index="29" href="/search/news-and-communications">News</a>
+                                <p class="govuk-body govuk-!-margin-0">News stories, speeches, letters and notices</p>
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-module="gem-track-click" data-track-action="governmentactivityLink" data-track-category="headerClicked" data-track-label="/search/guidance-and-regulation" data-track-dimension="Guidance and regulation" data-track-dimension-index="29" href="/search/guidance-and-regulation">Guidance and regulation</a>
+                                <p class="govuk-body govuk-!-margin-0">Detailed guidance, regulations and rules</p>
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-module="gem-track-click" data-track-action="governmentactivityLink" data-track-category="headerClicked" data-track-label="/search/research-and-statistics" data-track-dimension="Research and statistics" data-track-dimension-index="29" href="/search/research-and-statistics">Research and statistics</a>
+                                <p class="govuk-body govuk-!-margin-0">Reports, analysis and official statistics</p>
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-module="gem-track-click" data-track-action="governmentactivityLink" data-track-category="headerClicked" data-track-label="/search/policy-papers-and-consultations" data-track-dimension="Policy papers and consultation" data-track-dimension-index="29" href="/search/policy-papers-and-consultations">Policy papers and consultation</a>
+                                <p class="govuk-body govuk-!-margin-0">Consultations and strategy</p>
+                              </li>
+                              <li class="gem-c-layout-super-navigation-header__dropdown-list-item">
+                                <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-item-link gem-c-layout-super-navigation-header__navigation-second-item-link--with-description" data-module="gem-track-click" data-track-action="governmentactivityLink" data-track-category="headerClicked" data-track-label="/search/transparency-and-freedom-of-information-releases" data-track-dimension="Transparency" data-track-dimension-index="29" href="/search/transparency-and-freedom-of-information-releases">Transparency</a>
+                                <p class="govuk-body govuk-!-margin-0">Government data, Freedom of Information releases and corporate reports</p>
+                              </li>
+                          </ul>
+                      </div>
+                  </div>
+                    <div class="govuk-grid-row">
+                      <div class="govuk-grid-column-full">
+                        <div class="gem-c-layout-super-navigation-header__navigation-second-footer">
+                          <div class="govuk-grid-row">
+                            <ul class="gem-c-layout-super-navigation-header__navigation-second-footer-list">
+                                <li class="gem-c-layout-super-navigation-header__navigation-second-footer-item">
+                                  <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-footer-link" data-module="gem-track-click" data-track-action="governmentactivityLink" data-track-category="headerClicked" data-track-label="/government/how-government-works" data-track-dimension="How government works" data-track-dimension-index="29" href="/government/how-government-works">How government works</a>
+                                </li>
+                                <li class="gem-c-layout-super-navigation-header__navigation-second-footer-item">
+                                  <a class="govuk-link gem-c-layout-super-navigation-header__navigation-second-footer-link" data-module="gem-track-click" data-track-action="governmentactivityLink" data-track-category="headerClicked" data-track-label="/government/get-involved" data-track-dimension="Get involved" data-track-dimension-index="29" href="/government/get-involved">Get involved</a>
+                                </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                </div>
               </div>
-              <div class="govuk-grid-column-one-third">
-                <ul>
-                  <li><a href="/browse/driving">Driving and transport</a></li>
-                  <li><a href="/browse/education">Education and learning</a></li>
-                  <li><a href="/browse/employing-people">Employing people</a></li>
-                  <li><a href="/browse/environment-countryside">Environment and countryside</a></li>
-                  <li><a href="/browse/housing-local-services">Housing and local services</a></li>
-                  <li><a href="/browse/tax">Money and tax</a></li>
-                  <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>
-                  <li><a href="/browse/visas-immigration">Visas and immigration</a></li>
-                  <li><a href="/browse/working">Working, jobs and pensions</a></li>
-                </ul>
-              </div>
-            </div>
-          </div>
+</li>      </ul>
+
+      <button aria-controls="super-search-menu" aria-expanded="true" aria-label="Hide search menu" class="gem-c-layout-super-navigation-header__search-toggle-button" data-text-for-hide="Hide search menu" data-text-for-show="Show search menu" data-toggle-mobile-group="top" data-toggle-desktop-group="top" data-tracking-key="search" hidden="" id="super-search-menu-toggle" type="button">
+        <span class="govuk-visually-hidden">
+          Search GOV.UK
+        </span>
+        <svg class="gem-c-layout-super-navigation-header__search-toggle-button-link-icon" width="27" height="27" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+          <circle cx="10.0161" cy="10.0161" r="8.51613" stroke="currentColor" stroke-width="3"></circle>
+          <line x1="15.8668" y1="16.3587" x2="25.4475" y2="25.9393" stroke="currentColor" stroke-width="3"></line>
+        </svg>
+      </button>
+
+      <div id="super-search-menu" class="gem-c-layout-super-navigation-header__search-items">
+        <h3 class="govuk-visually-hidden">
+          Search
+        </h3>
+        <div class="gem-c-layout-super-navigation-header__search-item">
+          <a class="gem-c-layout-super-navigation-header__search-item-link" href="/search">
+            <span class="gem-c-layout-super-navigation-header__search-item-link-text">
+              Search GOV.UK
+            </span>
+            <svg class="gem-c-layout-super-navigation-header__search-item-link-icon" width="27" height="27" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+              <circle cx="10.0161" cy="10.0161" r="8.51613" stroke="currentColor" stroke-width="3"></circle>
+              <line x1="15.8668" y1="16.3587" x2="25.4475" y2="25.9393" stroke="currentColor" stroke-width="3"></line>
+            </svg>
+          </a>
         </div>
 
-        <div class="xpl-frame2" id="xpl-frame2-activity" style="display: none">
-          <div class="xpl-frame2-inner">
-            <div class="govuk-grid-row">
-              <div class="govuk-grid-column-one-third">
-                <p class="xpl-dropdown-intro">Find out what the government is doing and how to get involved</p>
-              </div>
-              <div class="govuk-grid-column-one-third">
-                <ul>
-                  <li>
-                    <a href="/search/news-and-communications">News</a>
-                    <p>News stories, speeches, letters and notices</p>
-                  </li>
-                  <li>
-                    <a href="/search/guidance-and-regulation">Guidance and regulation</a>
-                    <p>Detailed guidance, rules and regulations</p>
-                  </li>
-                  <li>
-                    <a href="/search/research-and-statistics">Research and statistics</a>
-                    <p>Reports, analysis and official statistics</p>
-                  </li>
-                </ul>
-              </div>
-              <div class="govuk-grid-column-one-third">
-                <ul>
-                  <li>
-                    <a href="/search/policy-papers-and-consultations">Policy papers and consultation</a>
-                    <p>Consultations and strategy</p>
-                  </li>
-                  <li>
-                    <a href="/search/transparency-and-freedom-of-information-releases">Transparency</a>
-                    <p>Government data, freedom of information releases and corporate reports</p>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            <div class="govuk-grid-row xpl-minor-item">
-              <div class="govuk-grid-column-one-third">
-                <br/>
-              </div>
-              <div class="govuk-grid-column-one-third">
-                <a href="/government/how-government-works">How government works</a>
-              </div>
-              <div class="govuk-grid-column-one-third">
-                <a href="/government/get-involved">Get involved</a>
-              </div>
-            </div>
-          </div>
-        </div>
-
-
-        <!-- Desktop search menu -->
-        <div class="xpl-frame2" id="xpl-frame2-search" style="display: none">
-          <div class="xpl-frame2-inner">
-            <form action="/search/all" method="get" class="xpl-menu-search-input">
-              <div class="govuk-form-group">
-                <h2 class="govuk-label-wrapper"><label class="govuk-label govuk-label--m" for="desktop-search">
-                  Search GOV.UK
-                </label>
-                </h2>
-                <div class="govuk-input__wrapper"><input class="govuk-input" id="desktop-search" name="keywords" type="text" spellcheck="false">
-                  <button class="govuk-input__suffix" aria-hidden="true">Search</button>
-                </div>
-              </div>
-            </form>
-            <h2 class="govuk-heading-l">Most viewed</h2>
-            <ul class="govuk-list">
-              <li><a href="/">Coronavirus: find your area's tier</a></li>
-              <li><a href="/">Coronavirus: travel advice</a></li>
-              <li><a href="/">Coronavirus: social distancing rules</a></li>
-              <li><a href="/">Sign in to Universal Credit</a></li>
-              <li><a href="/">Brexit transition: check the new rules for January 2021</a></li>
-            </ul>
-          </div>
-        </div>
-      </nav>
-
-
-      <!-- mobile menu -->
-
-      <nav class="xpl-nav">
-        <button id="xpl-menu-button" type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu" aria-expanded="false">Menu</button>
-        <button id="xpl-search-button" type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="search" aria-label="Show or hide search menu" aria-expanded="false">Search</button>
-
-        <div id="xpl-popup-menu" style="display:none">
-          <div id="navigation">
-            <div class="xpl-accordion" data-module="xpl-accordion" id="xpl-accordion-default">
-              <div class="xpl-accordion__section">
-                <div class="xpl-accordion__section-header">
-                  <h2 class="xpl-accordion__section-heading">
-                    <span class="xpl-accordion__section-button" id="xpl-accordion-default-heading-1">
-                      Topics
-                    </span>
-                  </h2>
-                </div>
-                <div id="xpl-accordion-default-content-1" class="xpl-accordion__section-content" aria-labelledby="xpl-accordion-default-heading-1">
-                  <ul class="govuk-list">
-                    <li><a href="/browse/benefits">Benefits</a></li>
-                    <li><a href="/browse/births-deaths-marriages">Births, death, marriages and care</a></li>
-                    <li><a href="/brexit">Brexit</a></li>
-                    <li><a href="/browse/business">Business and self-employed</a></li>
-                    <li><a href="/browse/childcare-parenting">Childcare and parenting</a></li>
-                    <li><a href="/browse/citizenship">Citizenship and living in the UK</a></li>
-                    <li><a href="/coronavirus">Coronavirus</a></li>
-                    <li><a href="/browse/justice">Crime, justice and the law</a></li>
-                    <li><a href="/browse/disabilities">Disabled people</a></li>
-                    <li><a href="/browse/driving">Driving and transport</a></li>
-                    <li><a href="/browse/education">Education and learning</a></li>
-                    <li><a href="/browse/employing-people">Employing people</a></li>
-                    <li><a href="/browse/environment-countryside">Environment and countryside</a></li>
-                    <li><a href="/browse/housing-local-services">Housing and local services</a></li>
-                    <li><a href="/browse/tax">Money and tax</a></li>
-                    <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>
-                    <li><a href="/browse/visas-immigration">Visas and immigration</a></li>
-                    <li><a href="/browse/working">Working, jobs and pensions</a></li>
-                  </ul>
-                </div>
-              </div>
-              <div class="xpl-accordion__section-link">
-                <div class="xpl-accordion__section-header">
-                  <h2 class="xpl-accordion__section-heading">
-                    <a href="/government/organisations" id="xpl-accordion-default-heading-2">
-                      Departments
-                    </a>
-                  </h2>
-                </div>
-              </div>
-              <div class="xpl-accordion__section">
-                <div class="xpl-accordion__section-header">
-                  <h2 class="xpl-accordion__section-heading">
-                    <span class="xpl-accordion__section-button" id="xpl-accordion-default-heading-3">
-                      Government activity
-                    </span>
-                  </h2>
-                </div>
-                <div id="xpl-accordion-default-content-3" class="xpl-accordion__section-content" aria-labelledby="xpl-accordion-default-heading-3">
-                  <ul class="govuk-list xpl-gov-activity">
-                    <li class="govuk-header__navigation-item-2">
-                      <a class="govuk-header__link" href="/search/news-and-communications">News</a><br/>
-                      <p>News stories, speeches, letters and notices</p>
-                    </li>
-                    <li class="govuk-header__navigation-item-2">
-                      <a class="govuk-header__link" href="/search/guidance-and-regulation">Guidance and regulation</a><br/>
-                      <p>Detailed guidance, rules and regulations</p>
-                    </li>
-                    <li class="govuk-header__navigation-item-2">
-                      <a class="govuk-header__link" href="/search/research-and-statistics">Research and statistics</a><br/>
-                      <p>Reports, analysis and statistics</p>
-                    </li>
-                    <li class="govuk-header__navigation-item-2">
-                      <a class="govuk-header__link" href="/search/policy-papers-and-consultations">Policy papers and consultations</a><br/>
-                      <p>Plans, proposals and consultations</p>
-                    </li>
-                    <li class="govuk-header__navigation-item-2">
-                      <a class="govuk-header__link" href="/search/transparency-and-freedom-of-information-releases">Transparency documents</a><br/>
-                      <p>Government data, freedom of information responses and corporate reports</p>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-            <ul class="govuk-list xpl-below-accordion">
-              <li class="govuk-header__navigation-item xpl-minor-nav-item">
-                <a href="/government/how-government-works">How government works</a>
-              </li>
-              <li class="govuk-header__navigation-item xpl-minor-nav-item">
-                <a href="/government/get-involved">Get involved</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <div id="xpl-popup-search" style="display:none">
-          <h2 class="govuk-heading-l">Search GOV.UK</h2>
-          <form action="/search/all" method="get" class="xpl-menu-search-input">
-            <div class="govuk-input__wrapper"><input class="govuk-input" id="desktop-search" name="keywords" type="text" spellcheck="false"><button class="govuk-input__suffix" aria-hidden="true">Search</button>
-            </div>
-          </form>
-
-          <h2 class="govuk-heading-l">Most viewed</h2>
-          <ul class="govuk-list">
-            <li><a href="/">Coronavirus: find your area's tier</a></li>
-            <li><a href="/">Coronavirus: travel advice</a></li>
-            <li><a href="/">Coronavirus: social distancing rules</a></li>
-            <li><a href="/">Sign in to Universal Credit</a></li>
-            <li><a href="/">Brexit transition: check the new rules for January 2021</a></li>
-          </ul>
-        </div>
-      </nav>
-    </div>
+        <div class="govuk-width-container gem-c-layout-super-navigation-header__search-and-popular">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+              <form class="gem-c-layout-super-navigation-header__search-form" id="search" action="/search" method="get" role="search" aria-label="Site-wide">
+                
+<div class="gem-c-search govuk-!-display-none-print  gem-c-search--large gem-c-search--on-white gem-c-search--separate-label" data-module="gem-toggle-input-class-on-focus">
+  <label for="search-main-b256ad2e" class="govuk-label govuk-label--m">
+    Search GOV.UK
+</label>  <div class="gem-c-search__item-wrapper">
+    <input class="gem-c-search__item gem-c-search__input js-class-toggle" id="search-main-b256ad2e" name="q" title="Search" type="search" value="">
+    <div class="gem-c-search__item gem-c-search__submit-wrapper">
+      <button class="gem-c-search__submit" type="submit" data-track-category="headerClicked" data-track-action="searchSubmitted" data-track-label="/search/all" data-track-dimension="Search on GOV.UK" data-track-dimension-index="29" data-module="gem-track-click">
+        Search
+</button>    </div>
   </div>
-  <script src="/public/javascripts/explore-header-accordion.js"></script>
+</div>
+
+              </form>
+            </div>
+          </div>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+              <h3 class="govuk-heading-m">Popular on GOV.UK</h3>
+              <ul class="govuk-list">
+                  <li class="gem-c-layout-super-navigation-header__popular-item">
+                    <a class="govuk-link gem-c-layout-super-navigation-header__popular-link" href="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do" data-module="gem-track-click" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do" data-track-dimension="Coronavirus (COVID-19): guidance" data-track-dimension-index="29">
+                      Coronavirus (COVID-19): guidance
+                    </a>
+                  </li>
+                  <li class="gem-c-layout-super-navigation-header__popular-item">
+                    <a class="govuk-link gem-c-layout-super-navigation-header__popular-link" href="/brexit" data-module="gem-track-click" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/brexit" data-track-dimension="Brexit: check what you need to do" data-track-dimension-index="29">
+                      Brexit: check what you need to do
+                    </a>
+                  </li>
+                  <li class="gem-c-layout-super-navigation-header__popular-item">
+                    <a class="govuk-link gem-c-layout-super-navigation-header__popular-link" href="/personal-tax-account" data-module="gem-track-click" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/personal-tax-account" data-track-dimension="Sign in to your personal tax account" data-track-dimension-index="29">
+                      Sign in to your personal tax account
+                    </a>
+                  </li>
+                  <li class="gem-c-layout-super-navigation-header__popular-item">
+                    <a class="govuk-link gem-c-layout-super-navigation-header__popular-link" href="/find-a-job" data-module="gem-track-click" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/find-a-job" data-track-dimension="Find a job" data-track-dimension-index="29">
+                      Find a job
+                    </a>
+                  </li>
+                  <li class="gem-c-layout-super-navigation-header__popular-item">
+                    <a class="govuk-link gem-c-layout-super-navigation-header__popular-link" href="/sign-in-universal-credit" data-module="gem-track-click" data-track-action="popularLink" data-track-category="headerClicked" data-track-label="/sign-in-universal-credit" data-track-dimension="Sign in to your Universal Credit account" data-track-dimension-index="29">
+                      Sign in to your Universal Credit account
+                    </a>
+                  </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </div>
 </header>

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -10,6 +10,12 @@
 <script src="/public/javascripts/xpl-tabs.js"></script>
 <script src="/public/javascripts/govuk-accordion.js"></script>
 
+<script>
+  // Find first header module to enhance.
+  var $header = document.querySelector('[data-module="govuk-header"]');
+  new GOVUK.Modules.Header($header).init();
+</script>
+
 {% if useAutoStoreData %}
   <script src="/public/javascripts/auto-store-data.js"></script>
 {% endif %}


### PR DESCRIPTION
## What/Why
Updates the header to use the push-down menu open style over the overlay menu open style as the latter is inaccessible. For pages where we pull data directly rom static and don't have a template in the prototype eg: https://www.gov.uk/government/organisations we simply remove the existing replacement of the old header with the new header that was in the prototype up until now. This is no longer needed as the new header is on the live site.

No visual changes.