### PR TITLE
Make collection documents rendering reflect live

### DIFF
--- a/app/views/generic_template.html
+++ b/app/views/generic_template.html
@@ -90,21 +90,29 @@
             </dl>
           </div>
 
-          {% if contents_list.length %}
+          {% if (contents_list.length) or (document_collections) %}
             <nav class="gem-c-contents-list" aria-label="Contents" role="navigation">
               <h2 class="gem-c-contents-list__title">Contents</h2>
               <ol class="gem-c-contents-list__list">
-                {% for item in contents_list %}
-                  <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-                    {% if item.id %}
-                      <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#{{ item.id }}">{{ item.text }}</a>
-                    {% elif item.is_current_page %}
-                      {{ item.text }}
-                    {% else %}
-                      <a class="gem-c-contents-list__link govuk-link govuk-link" href="{{ item.slug }}">{{ item.text }}</a>
-                    {% endif %}
-                  </li>
-                {% endfor %}
+                {% if document_collections %}
+                  {% for collection in document_collections %}
+                    <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+                      <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#{{ collection.slug }}">{{ collection.title }}</a>
+                    </li>
+                  {% endfor %}
+                {% else %}
+                  {% for item in contents_list %}
+                    <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+                      {% if item.id %}
+                        <a class="gem-c-contents-list__link govuk-link govuk-link--no-underline" href="#{{ item.id }}">{{ item.text }}</a>
+                      {% elif item.is_current_page %}
+                        {{ item.text }}
+                      {% else %}
+                        <a class="gem-c-contents-list__link govuk-link govuk-link" href="{{ item.slug }}">{{ item.text }}</a>
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                {% endif %}
               </ol>
             </nav>
           {% endif %}
@@ -192,38 +200,28 @@
             </div>
           {% endif %}
 
-          {% if main_document %}
-            <h2 class="govuk-heading-m govuk-!-padding-0 govuk-!-margin-top-8 govuk-!-margin-bottom-4">{{ main_document.title }}</h2>
-            <ul class="gem-c-document-list">
-              <li class="gem-c-document-list__item">
-                <a class="gem-c-document-list__item-title govuk-link" href="{{ main_document.base_path }}">{{ main_document.title }}</a>
-                  <ul class="gem-c-document-list__item-metadata">
-                    <li class="gem-c-document-list__attribute">
-                      <time datetime="{{ main_document.public_updated_at }}">
-                        {{ main_document.formatted_date }}
-                      </time>
-                    </li>
-                    <li class="gem-c-document-list__attribute">{{ main_document.attribute }}</li>
-                  </ul>
-              </li>
-            </ul>
-          {% endif %}
-
-          {% if archived_documents %}
-            <h2 class="govuk-heading-m govuk-!-padding-0 govuk-!-margin-top-8 govuk-!-margin-bottom-4">Archived documents</h2>
-            {% for doc in archived_documents %}
+          {% if document_collections %}
+            {% for collection in document_collections %}
+              <h2 class="govuk-heading-m govuk-!-padding-0 govuk-!-margin-top-8 govuk-!-margin-bottom-4" id="{{ collection.slug }}">{{ collection.title }}</h2>
+              {% if collection.body %}
+                <div class="gem-c-govspeak govuk-govspeak" data-module="govspeak">
+                  {{ collection.body|safe }}
+                </div>
+              {% endif %}
               <ul class="gem-c-document-list">
-                <li class="gem-c-document-list__item">
-                  <a class="gem-c-document-list__item-title govuk-link" href="{{ doc.base_path }}">{{ doc.title }}</a>
+                {% for document in collection.documents %}
+                  <li class="gem-c-document-list__item">
+                    <a class="gem-c-document-list__item-title govuk-link" href="{{ document.base_path }}">{{ document.title }}</a>
                     <ul class="gem-c-document-list__item-metadata">
                       <li class="gem-c-document-list__attribute">
-                        <time datetime="{{ doc.public_updated_at }}">
-                          {{ doc.formatted_date }}
+                        <time datetime="{{ document.public_updated_at }}">
+                          {{ document.formatted_date }}
                         </time>
                       </li>
-                      <li class="gem-c-document-list__attribute">{{ doc.attribute }}</li>
+                      <li class="gem-c-document-list__attribute">{{ document.attribute }}</li>
                     </ul>
-                </li>
+                  </li>
+                {% endfor %}
               </ul>
             {% endfor %}
           {% endif %}


### PR DESCRIPTION
## What/Why
When I initially built the collections portion of the generic template I hadn't built it properly, incorrectly presuming how collections documents were organised. This fixes it.

### Test pages:
- https://explore-prot-get-collec-ou3drg.herokuapp.com//government/collections/moving-goods-into-out-of-or-through-northern-ireland
- https://explore-prot-get-collec-ou3drg.herokuapp.com/government/collections/building-safety-bill

Relies on https://github.com/alphagov/govuk-explore-api-prototype/pull/30

Trello https://trello.com/c/PvpE53SR/589-contents-lists-on-collections-not-working-as-expected