### PR TITLE
Hide lede paragraph and metadata on local transactions

### DIFF
--- a/app/views/generic_template.html
+++ b/app/views/generic_template.html
@@ -48,7 +48,7 @@
           {% endif %}
 
           <h1 class="govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-8 govuk-!-padding-top-0">{{ title }}</h1>
-          {% if not is_mainstream_guide %}
+          {% if (not is_mainstream_guide) and (not show_form) %}
             <p class="lede govuk-body-l">
               {% if context %}
                 <strong>{{context}}</strong>
@@ -66,7 +66,7 @@
       
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          {% if not details|isArray %}
+          {% if (not details|isArray) and (not show_form) %}
             <div class="gem-c-metadata" data-module="gem-toggle">
               <dl>
                 <dt class="gem-c-metadata__term">From:</dt>


### PR DESCRIPTION
## What/Why
Hides the lede paragraph and metadata on local transaction pages as these are hidden on live so we want to replicate live as much as possible.

Page tested on: https://www.gov.uk/search-register-planning-decisions
Card: https://trello.com/c/oJBkkBM5/601-local-transaction-pages-have-a-description-text-below-the-page-title-that-should-not-be-there

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-10-22 at 15 39 53](https://user-images.githubusercontent.com/64783893/138474687-57eede9d-15a3-4965-9903-aa703ea0b039.png) | ![Screenshot 2021-10-22 at 15 40 00](https://user-images.githubusercontent.com/64783893/138474698-09e58d92-df35-46c0-aec8-885ce5b3b723.png) |